### PR TITLE
Support for Visus WebViewer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -304,6 +304,12 @@ services:
     networks:
       - default
       - dbnetwork
+      
+  visus-server:
+    container_name: visus-server
+    image: visus/visus
+    networks:
+      - default
 
   # FTP server
   #esgf-ftp:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -416,6 +416,17 @@ services:
       replicas: 1
       placement:
         constraints: [node.labels.esgf_idp_node == true]
+        
+  visus-server:
+    container_name: visus-server
+    image: visus/visus
+    networks:
+      - default
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints: [node.labels.esgf_front_node == true]
 
   # useful visualizer container, not really needed
   visualizer:

--- a/esgf_config/httpd/conf/esgf-httpd.conf
+++ b/esgf_config/httpd/conf/esgf-httpd.conf
@@ -109,7 +109,12 @@ WSGISocketPrefix run/wsgi
   ProxyPassReverse /esgf-slcs http://esgf-slcs:5000 timeout=600
   ProxyPass /slcs-static http://slcs-nginx timeout=600
   ProxyPassReverse /slcs-static http://slcs-nginx timeout=600
-
+  
+  # proxy requests for visus web viewer
+  ProxyPass /visusviewer http://visus-server timeout=600
+  ProxyPassReverse /visusviewer http://visus-server timeout=600
+  RewriteRule (.*/visusviewer) https://%{HTTP_HOST}%{REQUEST_URI}/viewer.html [R,L]
+  
   # Node Manager
   WSGIDaemonProcess esgfnm python-path=/opt/esgf/virtual/python/lib/python2.7/site-packages:/usr/local/esgf-node-manager/src/python/server user=apache group=apache threads=5
   WSGIScriptAlias /esgf-nm /usr/local/esgf-node-manager/src/python/server/nodemgr/apache/wsgi.py


### PR DESCRIPTION
This will enable the Visus webviewer to be deployed as part of the ESGF stack.

When using stack deploy, it is deployed to the `esgf_front_node` node.

Currently, this should be considered the WebViewer **only**. It cannot convert NetCDF to IDX at all (on-demand or otherwise). Still working with the folks at SCI to work out on-demand conversion of NetCDF.