### PR TITLE
Update esgf-auth version and settings

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Clone the github repo and checkout the specified version
-ARG ESGF_AUTH_GIT_VERSION=master
+ARG ESGF_AUTH_GIT_VERSION=v1.0-alpha
 RUN git clone https://github.com/ESGF/esgf-auth.git /application && \
     cd /application && \
     git checkout $ESGF_AUTH_GIT_VERSION && \
@@ -48,16 +48,17 @@ COPY --from=esgf-auth-build /application /application
 COPY --from=esgf-auth-build /pip-wheels  /pip-wheels
 
 # Install the dependency wheels (remove the wheels when we are done)
-RUN pip install --no-index --find-links=/pip-wheels -r /application/requirements.txt && \
-    pip install --no-index --find-links=/pip-wheels crypto-cookie && \
+RUN pip install --no-index --find-links=/pip-wheels crypto-cookie && \
     pip install --no-index --find-links=/pip-wheels psycopg2 && \
+    pip install --no-index --find-links=/pip-wheels -r /application/requirements.txt && \
     rm -rf /pip-wheels
 
 # Because esgf-auth has no setup.py, we can't use pip install -e /application
 # Instead, we add /application to the PYTHONPATH
 ENV PYTHONPATH /application:$PYTHONPATH
+ENV ESGF_AUTH_INSTALL_DIR /application
 
-# Install ESGF Auth settings wrappers
+# Install ESGF Auth settings wrapper
 COPY python/*.py /usr/local/lib/python2.7/site-packages/
 
 # Install configuration files
@@ -68,9 +69,11 @@ COPY --chown=1001:0 --from=configuration /esg/config /esg/config
 COPY --from=configuration /opt/esgf-docker/scripts/interpolate-configs.sh /django-init.d/01-interpolate.sh
 # Install the template auth config file
 ENV ESGF_AUTH_CONFIG_FILE /esg/auth/esgf_auth_config.json
+ENV ESGF_OAUTH2_SECRET_FILE /esg/auth/esgf_oauth2.json
 # Ensure /esg/auth exists and is owned by the Django user and root group
 RUN mkdir -p /esg/auth && chown 1001:0 /esg/auth && chmod 775 /esg/auth
 COPY conf/esgf_auth_config.json.template "$ESGF_AUTH_CONFIG_FILE.template"
+RUN echo "{}" > $ESGF_OAUTH2_SECRET_FILE
 # This script interpolates the auth config files with additional environment variables
 COPY scripts/auth-configure.sh /django-init.d/02-auth-configure.sh
 

--- a/auth/python/esgf_auth_settings.py
+++ b/auth/python/esgf_auth_settings.py
@@ -22,7 +22,10 @@ for name, value in os.environ.items():
 
 
 # Configure staticfiles app
+STATICFILES_DIRS = [
+    os.environ['ESGF_AUTH_INSTALL_DIR'] + '/static',
+]
 STATIC_ROOT = os.environ['DJANGO_STATIC_ROOT']
 # Check if we are running under a prefix
 if 'SCRIPT_NAME' in os.environ:
-    STATIC_URL = os.environ['SCRIPT_NAME'] + STATIC_URL
+    STATIC_URL = STATIC_URL.replace('/esgf-auth', os.environ['SCRIPT_NAME'])


### PR DESCRIPTION
esgf-auth now works, and can use the OpenID provider.

This patch does not deal with populating the OAuth2 secrets file (it is left as an empty JSON map). This is on purpose. We should use whatever technique the IdEA WT agrees on for auto-registration, but this has not been developed yet.

Fixes #50 