### PR TITLE
Integrate Helm charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 ESGF software stack as Docker images.
 
-## Documentation
+## Documentation
 
 For documentation, please visit [cedadev.github.io/esgf-docker](https://cedadev.github.io/esgf-docker).

--- a/bin/esgf-setup
+++ b/bin/esgf-setup
@@ -13,6 +13,8 @@ fi
 : ${ESGF_PREFIX:=}
 : ${ESGF_VERSION:=latest}
 
+export ESGF_CONFIG ESGF_HUB ESGF_PREFIX ESGF_VERSION
+
 # Run the given command in the docker container with the required environment variables and volumes
 # It requires:
 #   * The actual value of the ESGF_CONFIG variable for interpolation

--- a/cluster/kubernetes/charts/Chart.yaml
+++ b/cluster/kubernetes/charts/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+name: esgf-node
+version: 0.1.0
+description: Helm chart for deploying an ESGF node.

--- a/cluster/kubernetes/charts/templates/_helpers.tpl
+++ b/cluster/kubernetes/charts/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Template providing the default labels for a resource.
+*/}}
+{{- define "default-labels" -}}
+app: {{ template "name" . }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+release: {{ .Release.Name }}
+heritage: {{ .Release.Service }}
+{{- end -}}

--- a/cluster/kubernetes/charts/templates/auth/deployment-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/auth/deployment-postgres.yaml
@@ -24,6 +24,10 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
     spec:
+      # Setting fsGroup for the pod allows some provisioners to chown mounted volumes to the given group
+      #   The postgres group is 26 inside our container
+      securityContext:
+        fsGroup: 26
       containers:
         - name: postgres-auth
           image: "{{ .Values.auth.postgres.image.repository }}:{{ .Values.auth.postgres.image.tag }}"

--- a/cluster/kubernetes/charts/templates/auth/deployment-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/auth/deployment-postgres.yaml
@@ -1,0 +1,67 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-postgres-auth"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: auth
+    auth-role: database
+spec:
+  replicas: 1
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: auth
+      auth-role: database
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: auth
+        auth-role: database
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: postgres-auth
+          image: "{{ .Values.auth.postgres.image.repository }}:{{ .Values.auth.postgres.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.auth.postgres.image.pullPolicy | quote }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          env:
+            - name: POSTGRESQL_DATABASE
+              value: auth
+            - name: POSTGRESQL_USER
+              value: authuser
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "auth-database-password"
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/pgsql/data
+          resources:
+{{ toYaml .Values.auth.postgres.resources | indent 12 }}
+      volumes:
+        - name: postgres-data
+{{- if .Values.auth.postgres.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: "{{ template "fullname" . }}-postgres-auth"
+{{- else }}
+          emptyDir: {}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/auth/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/auth/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+        checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
     spec:
       initContainers:
         # Wait for postgres to become available before starting

--- a/cluster/kubernetes/charts/templates/auth/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/auth/deployment.yaml
@@ -1,0 +1,127 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-auth"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: auth
+    auth-role: frontend
+spec:
+  replicas: {{ .Values.auth.replicas }}
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: auth
+      auth-role: frontend
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: auth
+        auth-role: frontend
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
+        checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+        # Wait for postgres to become available before starting
+        - name: ensure-postgres
+          image: "{{ .Values.auth.postgres.image.repository }}:{{ .Values.auth.postgres.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.auth.postgres.image.pullPolicy | quote }}
+          env:
+            - name: PGHOST
+              value: "{{ template "fullname" . }}-postgres-auth"
+            - name: PGPORT
+              value: "5432"
+            - name: PGUSER
+              value: authuser
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "auth-database-password"
+            - name: PGDATABASE
+              value: auth
+          command:
+            # Try every 5 seconds for no longer than 10 mins
+            - bash
+            - -c
+            - |
+              for i in $(seq 120); do
+                sleep 5
+                echo "Attempt $i of 120"
+                if pg_isready; then exit 0; fi
+              done
+              exit 1
+      containers:
+        - name: auth
+          image: "{{ .Values.auth.image.repository }}:{{ .Values.auth.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.auth.image.pullPolicy | quote }}
+          ports:
+            - name: http
+              containerPort: 8000
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            httpGet:
+              path: /esgf-auth/home/
+              port: 8000
+              # The ALLOWED_HOSTS setting means that the app will only accept
+              # requests from the correct host
+              httpHeaders:
+                - name: Host
+                  value: "{{ .Values.hostname }}"
+                - name: X-Forwarded-Host
+                  value: "{{ .Values.hostname }}"
+                - name: X-Forwarded-Proto
+                  value: https
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          envFrom:
+            - configMapRef:
+                name: "{{ template "fullname" . }}-environment-common"
+          env:
+            - name: SCRIPT_NAME
+              value: /esgf-auth
+            - name: ESGF_AUTH_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "auth-secret-key"
+            - name: ESGF_COOKIE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "shared-cookie-secret-key"
+            # Database settings
+            - name: DJANGO_DATABASE_DEFAULT_ENGINE
+              value: django.db.backends.postgresql
+            - name: DJANGO_DATABASE_DEFAULT_NAME
+              value: auth
+            - name: DJANGO_DATABASE_DEFAULT_HOST
+              value: "{{ template "fullname" . }}-postgres-auth"
+            - name: DJANGO_DATABASE_DEFAULT_PORT
+              value: "5432"
+            - name: DJANGO_DATABASE_DEFAULT_USER
+              value: authuser
+            - name: DJANGO_DATABASE_DEFAULT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "auth-database-password"
+          volumeMounts:
+            - mountPath: /esg/certificates/esg-trust-bundle.pem
+              name: trust-bundle
+              subPath: esg-trust-bundle.pem
+          resources:
+{{ toYaml .Values.auth.resources | indent 12 }}
+      volumes:
+        - name: trust-bundle
+          configMap:
+            name: "{{ template "fullname" . }}-trust-bundle"

--- a/cluster/kubernetes/charts/templates/auth/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/auth/deployment.yaml
@@ -25,10 +25,32 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
         checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
-        checksum/esg-config-overrides: {{ include (print $.Template.BasePath "/configuration/esg-config-overrides.yaml") . | sha256sum }}
-        checksum/auth-overrides: {{ include (print $.Template.BasePath "/configuration/auth-overrides.yaml") . | sha256sum }}
+        checksum/config-overrides: {{ include (print $.Template.BasePath "/configuration/config-overrides.yaml") . | sha256sum }}
     spec:
       initContainers:
+        # Unpack the required config overrides from the base64-encoded tarballs in the configmap
+        # This process is required because configmaps cannot contain nested directory structures
+        - name: unpack-config-overrides
+          image: busybox
+          command:
+            - "sh"
+            - "-c"
+            - |
+              set -eo pipefail
+              if [ -f /esg/tarballs/auth-overrides.tar.gz.b64 ]; then
+                  base64 -d /esg/tarballs/auth-overrides.tar.gz.b64 | tar -xz -C /esg/auth
+              fi
+              if [ -f /esg/tarballs/esg-config-overrides.tar.gz.b64 ]; then
+                  base64 -d /esg/tarballs/esg-config-overrides.tar.gz.b64 | tar -xz -C /esg/config
+              fi
+          volumeMounts:
+            - mountPath: /esg/auth
+              name: auth-overrides
+            - mountPath: /esg/config
+              name: esg-config-overrides
+            - mountPath: /esg/tarballs
+              name: override-tarballs
+              readOnly: true
         # Wait for postgres to become available before starting
         - name: ensure-postgres
           image: "{{ .Values.auth.postgres.image.repository }}:{{ .Values.auth.postgres.image.tag }}"
@@ -136,8 +158,9 @@ spec:
           configMap:
             name: "{{ template "fullname" . }}-trust-bundle"
         - name: esg-config-overrides
-          configMap:
-            name: "{{ template "fullname" . }}-esg-config-overrides"
+          emptyDir: {}
         - name: auth-overrides
+          emptyDir: {}
+        - name: override-tarballs
           configMap:
-            name: "{{ template "fullname" . }}-auth-overrides"
+            name: "{{ template "fullname" . }}-config-overrides"

--- a/cluster/kubernetes/charts/templates/auth/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/auth/deployment.yaml
@@ -26,6 +26,7 @@ spec:
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
         checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
         checksum/esg-config-overrides: {{ include (print $.Template.BasePath "/configuration/esg-config-overrides.yaml") . | sha256sum }}
+        checksum/auth-overrides: {{ include (print $.Template.BasePath "/configuration/auth-overrides.yaml") . | sha256sum }}
     spec:
       initContainers:
         # Wait for postgres to become available before starting
@@ -125,6 +126,9 @@ spec:
             - mountPath: /esg/config/.overrides
               name: esg-config-overrides
               readOnly: true
+            - mountPath: /esg/auth/.overrides
+              name: auth-overrides
+              readOnly: true
           resources:
 {{ toYaml .Values.auth.resources | indent 12 }}
       volumes:
@@ -134,3 +138,6 @@ spec:
         - name: esg-config-overrides
           configMap:
             name: "{{ template "fullname" . }}-esg-config-overrides"
+        - name: auth-overrides
+          configMap:
+            name: "{{ template "fullname" . }}-auth-overrides"

--- a/cluster/kubernetes/charts/templates/auth/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/auth/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
         checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
+        checksum/esg-config-overrides: {{ include (print $.Template.BasePath "/configuration/esg-config-overrides.yaml") . | sha256sum }}
     spec:
       initContainers:
         # Wait for postgres to become available before starting
@@ -120,9 +121,16 @@ spec:
             - mountPath: /esg/certificates/esg-trust-bundle.pem
               name: trust-bundle
               subPath: esg-trust-bundle.pem
+              readOnly: true
+            - mountPath: /esg/config/.overrides
+              name: esg-config-overrides
+              readOnly: true
           resources:
 {{ toYaml .Values.auth.resources | indent 12 }}
       volumes:
         - name: trust-bundle
           configMap:
             name: "{{ template "fullname" . }}-trust-bundle"
+        - name: esg-config-overrides
+          configMap:
+            name: "{{ template "fullname" . }}-esg-config-overrides"

--- a/cluster/kubernetes/charts/templates/auth/pvc-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/auth/pvc-postgres.yaml
@@ -16,6 +16,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.auth.postgres.persistence.size }}
+{{- if .Values.auth.postgres.persistence.selector }}
   selector:
 {{ toYaml .Values.auth.postgres.persistence.selector | indent 4 }}
+{{- end }}
 {{- end }}

--- a/cluster/kubernetes/charts/templates/auth/pvc-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/auth/pvc-postgres.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.auth.postgres.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ template "fullname" . }}-postgres-auth"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: auth
+    auth-role: database
+spec:
+  accessModes:
+    - ReadWriteOnce
+{{- if .Values.auth.postgres.persistence.storageClass }}
+  storageClassName: "{{ .Values.auth.postgres.persistence.storageClass }}"
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.auth.postgres.persistence.size }}
+  selector:
+{{ toYaml .Values.auth.postgres.persistence.selector | indent 4 }}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/auth/service-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/auth/service-postgres.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-postgres-auth"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: auth
+    auth-role: database
+spec:
+  ports:
+    - name: postgres
+      port: 5432
+  selector:
+    release: {{ .Release.Name }}
+    component: auth
+    auth-role: database

--- a/cluster/kubernetes/charts/templates/auth/service.yaml
+++ b/cluster/kubernetes/charts/templates/auth/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-auth"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: auth
+    auth-role: frontend
+spec:
+  ports:
+    - name: http
+      port: 8000
+  selector:
+    release: {{ .Release.Name }}
+    component: auth
+    auth-role: frontend

--- a/cluster/kubernetes/charts/templates/cog/deployment-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/cog/deployment-postgres.yaml
@@ -24,6 +24,10 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
     spec:
+      # Setting fsGroup for the pod allows some provisioners to chown mounted volumes to the given group
+      #   The postgres group is 26 inside our container
+      securityContext:
+        fsGroup: 26
       containers:
         - name: postgres-cog
           image: "{{ .Values.cog.postgres.image.repository }}:{{ .Values.cog.postgres.image.tag }}"

--- a/cluster/kubernetes/charts/templates/cog/deployment-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/cog/deployment-postgres.yaml
@@ -1,0 +1,67 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-postgres-cog"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: cog
+    cog-role: database
+spec:
+  replicas: 1
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: cog
+      cog-role: database
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: cog
+        cog-role: database
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: postgres-cog
+          image: "{{ .Values.cog.postgres.image.repository }}:{{ .Values.cog.postgres.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.cog.postgres.image.pullPolicy | quote }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          env:
+            - name: POSTGRESQL_DATABASE
+              value: cogdb
+            - name: POSTGRESQL_USER
+              value: dbsuper
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "cog-database-password"
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/pgsql/data
+          resources:
+{{ toYaml .Values.cog.postgres.resources | indent 12 }}
+      volumes:
+        - name: postgres-data
+{{- if .Values.cog.postgres.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: "{{ template "fullname" . }}-postgres-cog"
+{{- else }}
+          emptyDir: {}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/cog/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/cog/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
         checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
+        checksum/esg-config-overrides: {{ include (print $.Template.BasePath "/configuration/esg-config-overrides.yaml") . | sha256sum }}
     spec:
       initContainers:
         # Wait for databases to become available before starting
@@ -153,15 +154,22 @@ spec:
             - mountPath: /esg/certificates/esg-trust-bundle.pem
               name: trust-bundle
               subPath: esg-trust-bundle.pem
+              readOnly: true
             - mountPath: /esg/config/.esg_pg_pass
               name: esg-secrets
               subPath: security-database-password
+              readOnly: true
             - mountPath: /esg/secrets/cog-database-password
               name: esg-secrets
               subPath: cog-database-password
+              readOnly: true
             - mountPath: /esg/config/.esgf_pass
               name: esg-secrets
               subPath: rootadmin-password
+              readOnly: true
+            - mountPath: /esg/config/.overrides
+              name: esg-config-overrides
+              readOnly: true
           resources:
 {{ toYaml .Values.cog.resources | indent 12 }}
       volumes:
@@ -171,3 +179,6 @@ spec:
         - name: esg-secrets
           secret:
             secretName: "{{ template "fullname" . }}-secrets"
+        - name: esg-config-overrides
+          configMap:
+            name: "{{ template "fullname" . }}-esg-config-overrides"

--- a/cluster/kubernetes/charts/templates/cog/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/cog/deployment.yaml
@@ -148,11 +148,11 @@ spec:
                 name: "{{ template "fullname" . }}-environment-common"
           env:
             - name: ESGF_COG_SITE_NAME
-              value: "Local CoG"
+              value: {{ default "Local CoG" .Values.cog.environment.ESGF_COG_SITE_NAME | quote }}
             - name: ESGF_COG_HOME_PROJECT
-              value: TestProject
+              value: {{ default "TestProject" .Values.cog.environment.ESGF_COG_HOME_PROJECT | quote }}
             - name: ESGF_COG_TIME_ZONE
-              value: "Europe/London"
+              value: {{ default "Europe/London" .Values.cog.environment.ESGF_COG_TIME_ZONE | quote }}
             - name: ESGF_COG_SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/cluster/kubernetes/charts/templates/cog/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/cog/deployment.yaml
@@ -1,0 +1,172 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-cog"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: cog
+    cog-role: frontend
+spec:
+  replicas: {{ .Values.cog.replicas }}
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: cog
+      cog-role: frontend
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: cog
+        cog-role: frontend
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
+        checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+        # Wait for databases to become available before starting
+        - name: ensure-postgres-security
+          image: "{{ .Values.cog.postgres.image.repository }}:{{ .Values.cog.postgres.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.cog.postgres.image.pullPolicy | quote }}
+          env:
+            - name: PGHOST
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_HOST
+            - name: PGPORT
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_PORT
+            - name: PGUSER
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_USER
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "security-database-password"
+            - name: PGDATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_NAME
+          command:
+            # Try every 5 seconds for no longer than 10 mins
+            - bash
+            - -c
+            - |
+              for i in $(seq 120); do
+                sleep 5
+                echo "Attempt $i of 120"
+                if pg_isready; then exit 0; fi
+              done
+              exit 1
+        - name: ensure-postgres-cog
+          image: "{{ .Values.cog.postgres.image.repository }}:{{ .Values.cog.postgres.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.cog.postgres.image.pullPolicy | quote }}
+          env:
+            - name: PGHOST
+              value: "{{ template "fullname" . }}-postgres-cog"
+            - name: PGPORT
+              value: "5432"
+            - name: PGUSER
+              value: dbsuper
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "cog-database-password"
+            - name: PGDATABASE
+              value: cogdb
+          command:
+            # Try every 5 seconds for no longer than 10 mins
+            - bash
+            - -c
+            - |
+              for i in $(seq 120); do
+                sleep 5
+                echo "Attempt $i of 120"
+                if pg_isready; then exit 0; fi
+              done
+              exit 1
+      containers:
+        - name: cog
+          image: "{{ .Values.cog.image.repository }}:{{ .Values.cog.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.cog.image.pullPolicy | quote }}
+          ports:
+            - name: http
+              containerPort: 8000
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            httpGet:
+              path: /
+              port: 8000
+              # The ALLOWED_HOSTS setting means that the app will only accept
+              # requests from the correct host
+              httpHeaders:
+                - name: Host
+                  value: "{{ .Values.hostname }}"
+                - name: X-Forwarded-Host
+                  value: "{{ .Values.hostname }}"
+                - name: X-Forwarded-Proto
+                  value: https
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          envFrom:
+            - configMapRef:
+                name: "{{ template "fullname" . }}-environment-common"
+          env:
+            - name: ESGF_COG_SITE_NAME
+              value: "Local CoG"
+            - name: ESGF_COG_HOME_PROJECT
+              value: TestProject
+            - name: ESGF_COG_TIME_ZONE
+              value: "Europe/London"
+            - name: ESGF_COG_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "cog-secret-key"
+            - name: ESGF_COG_DATABASE_HOST
+              value: "{{ template "fullname" . }}-postgres-cog"
+            - name: ESGF_COG_DATABASE_PORT
+              value: "5432"
+            - name: ESGF_COG_DATABASE_NAME
+              value: cogdb
+            - name: ESGF_COG_DATABASE_USER
+              value: dbsuper
+            - name: ESGF_COG_DATABASE_PASSWORD_FILE
+              value: /esg/secrets/cog-database-password
+          volumeMounts:
+            - mountPath: /esg/certificates/esg-trust-bundle.pem
+              name: trust-bundle
+              subPath: esg-trust-bundle.pem
+            - mountPath: /esg/config/.esg_pg_pass
+              name: esg-secrets
+              subPath: security-database-password
+            - mountPath: /esg/secrets/cog-database-password
+              name: esg-secrets
+              subPath: cog-database-password
+            - mountPath: /esg/config/.esgf_pass
+              name: esg-secrets
+              subPath: rootadmin-password
+          resources:
+{{ toYaml .Values.cog.resources | indent 12 }}
+      volumes:
+        - name: trust-bundle
+          configMap:
+            name: "{{ template "fullname" . }}-trust-bundle"
+        - name: esg-secrets
+          secret:
+            secretName: "{{ template "fullname" . }}-secrets"

--- a/cluster/kubernetes/charts/templates/cog/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/cog/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+        checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
     spec:
       initContainers:
         # Wait for databases to become available before starting

--- a/cluster/kubernetes/charts/templates/cog/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/cog/deployment.yaml
@@ -25,9 +25,27 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
         checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
-        checksum/esg-config-overrides: {{ include (print $.Template.BasePath "/configuration/esg-config-overrides.yaml") . | sha256sum }}
+        checksum/config-overrides: {{ include (print $.Template.BasePath "/configuration/config-overrides.yaml") . | sha256sum }}
     spec:
       initContainers:
+        # Unpack the required config overrides from the base64-encoded tarballs in the configmap
+        # This process is required because configmaps cannot contain nested directory structures
+        - name: unpack-config-overrides
+          image: busybox
+          command:
+            - "sh"
+            - "-c"
+            - |
+              set -eo pipefail
+              if [ -f /esg/tarballs/esg-config-overrides.tar.gz.b64 ]; then
+                  base64 -d /esg/tarballs/esg-config-overrides.tar.gz.b64 | tar -xz -C /esg/config
+              fi
+          volumeMounts:
+            - mountPath: /esg/config
+              name: esg-config-overrides
+            - mountPath: /esg/tarballs
+              name: override-tarballs
+              readOnly: true
         # Wait for databases to become available before starting
         - name: ensure-postgres-security
           image: "{{ .Values.cog.postgres.image.repository }}:{{ .Values.cog.postgres.image.tag }}"
@@ -180,5 +198,7 @@ spec:
           secret:
             secretName: "{{ template "fullname" . }}-secrets"
         - name: esg-config-overrides
+          emptyDir: {}
+        - name: override-tarballs
           configMap:
-            name: "{{ template "fullname" . }}-esg-config-overrides"
+            name: "{{ template "fullname" . }}-config-overrides"

--- a/cluster/kubernetes/charts/templates/cog/pvc-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/cog/pvc-postgres.yaml
@@ -16,6 +16,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.cog.postgres.persistence.size }}
+{{- if .Values.cog.postgres.persistence.selector }}
   selector:
 {{ toYaml .Values.cog.postgres.persistence.selector | indent 4 }}
+{{- end }}
 {{- end }}

--- a/cluster/kubernetes/charts/templates/cog/pvc-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/cog/pvc-postgres.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.cog.postgres.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ template "fullname" . }}-postgres-cog"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: cog
+    cog-role: database
+spec:
+  accessModes:
+    - ReadWriteOnce
+{{- if .Values.cog.postgres.persistence.storageClass }}
+  storageClassName: "{{ .Values.cog.postgres.persistence.storageClass }}"
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.cog.postgres.persistence.size }}
+  selector:
+{{ toYaml .Values.cog.postgres.persistence.selector | indent 4 }}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/cog/service-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/cog/service-postgres.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-postgres-cog"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: cog
+    cog-role: database
+spec:
+  ports:
+    - name: postgres
+      port: 5432
+  selector:
+    release: {{ .Release.Name }}
+    component: cog
+    cog-role: database

--- a/cluster/kubernetes/charts/templates/cog/service.yaml
+++ b/cluster/kubernetes/charts/templates/cog/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-cog"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: cog
+    cog-role: frontend
+spec:
+  ports:
+    - name: http
+      port: 8000
+  selector:
+    release: {{ .Release.Name }}
+    component: cog
+    cog-role: frontend

--- a/cluster/kubernetes/charts/templates/configuration/auth-overrides.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/auth-overrides.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ template "fullname" . }}-auth-overrides"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: configuration
+data:
+{{ toYaml .Values.authOverrides | indent 2 }}

--- a/cluster/kubernetes/charts/templates/configuration/config-overrides.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/config-overrides.yaml
@@ -6,4 +6,4 @@ metadata:
 {{ include "default-labels" . | indent 4 }}
     component: configuration
 data:
-{{ toYaml .Values.configuration | indent 2 }}
+{{ toYaml .Values.configuration.overrides | indent 2 }}

--- a/cluster/kubernetes/charts/templates/configuration/config-overrides.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/config-overrides.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ template "fullname" . }}-auth-overrides"
+  name: "{{ template "fullname" . }}-config-overrides"
   labels:
 {{ include "default-labels" . | indent 4 }}
     component: configuration
 data:
-{{ toYaml .Values.authOverrides | indent 2 }}
+{{ toYaml .Values.configuration | indent 2 }}

--- a/cluster/kubernetes/charts/templates/configuration/environment-common.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/environment-common.yaml
@@ -7,19 +7,19 @@ metadata:
     component: configuration
 data:
   ESGF_HOSTNAME: "{{ .Values.hostname }}"
-  ESGF_PEER_GROUP: esgf-test
-  ESGF_ATTRIBUTE_SERVICE_ENDPOINT: "https://{{ .Values.hostname }}/esgf-idp/saml/soap/secure/attributeService.htm"
-  ESGF_REGISTRATION_SERVICE_ENDPOINT: "https://{{ .Values.hostname }}/esgf-idp/secure/registrationService.htm"
-  ESGF_OPENID_ENDPOINT: "https://{{ .Values.hostname }}/esgf-idp/idp/openidServer.htm"
+  ESGF_PEER_GROUP: {{ default "esgf-test" .Values.configuration.environment.ESGF_PEER_GROUP | quote }}
+  ESGF_ATTRIBUTE_SERVICE_ENDPOINT: {{ default (printf "https://%s/esgf-idp/saml/soap/secure/attributeService.htm" .Values.hostname) .Values.configuration.environment.ESGF_ATTRIBUTE_SERVICE_ENDPOINT | quote }}
+  ESGF_REGISTRATION_SERVICE_ENDPOINT: {{ default (printf "https://%s/esgf-idp/secure/registrationService.htm" .Values.hostname) .Values.configuration.environment.ESGF_REGISTRATION_SERVICE_ENDPOINT | quote }}
+  ESGF_OPENID_ENDPOINT: {{ default (printf "https://%s/esgf-idp/idp/openidServer.htm" .Values.hostname) .Values.configuration.environment.ESGF_OPENID_ENDPOINT | quote }}
   ESGF_DATABASE_HOST: "{{ template "fullname" . }}-postgres-security"
   ESGF_DATABASE_PORT: "5432"
   ESGF_DATABASE_USER: dbsuper
   ESGF_DATABASE_NAME: esgcet
-  ESGF_SEARCH_SERVICE_ENDPOINT: "https://{{ .Values.hostname }}/esg-search/search"
-  ESGF_IDP_PEER: "{{ .Values.hostname }}"
-  ESGF_INDEX_PEER: "{{ .Values.hostname }}"
-  ESGF_PUBLISH_SERVICE_ENDPOINT: "https://{{ .Values.hostname }}/esg-search/remote/secure/client-cert/hessian/publishingService"
+  ESGF_SEARCH_SERVICE_ENDPOINT: {{ default (printf "https://%s/esg-search/search" .Values.hostname) .Values.configuration.environment.ESGF_SEARCH_SERVICE_ENDPOINT | quote }}
+  ESGF_IDP_PEER: {{ default .Values.hostname .Values.configuration.environment.ESGF_IDP_PEER | quote }}
+  ESGF_INDEX_PEER: {{ default .Values.hostname .Values.configuration.environment.ESGF_INDEX_PEER | quote }}
+  ESGF_PUBLISH_SERVICE_ENDPOINT: {{ default (printf "https://%s/esg-search/remote/secure/client-cert/hessian/publishingService" .Values.hostname) .Values.configuration.environment.ESGF_PUBLISH_SERVICE_ENDPOINT | quote }}
   ESGF_SOLR_QUERY_URL: "http://{{ template "fullname" . }}-solr-slave:8983/solr"
   ESGF_SOLR_PUBLISH_URL: "http://{{ template "fullname" . }}-solr-master:8983/solr"
-  ESGF_AUTHORIZATION_SERVICE_ENDPOINT: "https://{{ .Values.hostname }}/esg-orp/saml/soap/secure/authorizationService.htm"
-  ESGF_SLCS_ENDPOINT: "https://{{ .Values.hostname }}/esgf-slcs"
+  ESGF_AUTHORIZATION_SERVICE_ENDPOINT: {{ default (printf "https://%s/esg-orp/saml/soap/secure/authorizationService.htm" .Values.hostname) .Values.configuration.environment.ESGF_AUTHORIZATION_SERVICE_ENDPOINT | quote }}
+  ESGF_SLCS_ENDPOINT: {{ default (printf "https://%s/esgf-slcs" .Values.hostname) .Values.configuration.environment.ESGF_SLCS_ENDPOINT | quote }}

--- a/cluster/kubernetes/charts/templates/configuration/environment-common.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/environment-common.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ template "fullname" . }}-environment-common"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: configuration
+data:
+  ESGF_HOSTNAME: "{{ .Values.hostname }}"
+  ESGF_PEER_GROUP: esgf-test
+  ESGF_ATTRIBUTE_SERVICE_ENDPOINT: "https://{{ .Values.hostname }}/esgf-idp/saml/soap/secure/attributeService.htm"
+  ESGF_REGISTRATION_SERVICE_ENDPOINT: "https://{{ .Values.hostname }}/esgf-idp/secure/registrationService.htm"
+  ESGF_OPENID_ENDPOINT: "https://{{ .Values.hostname }}/esgf-idp/idp/openidServer.htm"
+  ESGF_DATABASE_HOST: "{{ template "fullname" . }}-postgres-security"
+  ESGF_DATABASE_PORT: "5432"
+  ESGF_DATABASE_USER: dbsuper
+  ESGF_DATABASE_NAME: esgcet
+  ESGF_SEARCH_SERVICE_ENDPOINT: "https://{{ .Values.hostname }}/esg-search/search"
+  ESGF_IDP_PEER: "{{ .Values.hostname }}"
+  ESGF_INDEX_PEER: "{{ .Values.hostname }}"
+  ESGF_PUBLISH_SERVICE_ENDPOINT: "https://{{ .Values.hostname }}/esg-search/remote/secure/client-cert/hessian/publishingService"
+  ESGF_SOLR_QUERY_URL: "http://{{ template "fullname" . }}-solr-slave:8983/solr"
+  ESGF_SOLR_PUBLISH_URL: "http://{{ template "fullname" . }}-solr-master:8983/solr"
+  ESGF_AUTHORIZATION_SERVICE_ENDPOINT: "https://{{ .Values.hostname }}/esg-orp/saml/soap/secure/authorizationService.htm"
+  ESGF_SLCS_ENDPOINT: "https://{{ .Values.hostname }}/esgf-slcs"

--- a/cluster/kubernetes/charts/templates/configuration/esg-config-overrides.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/esg-config-overrides.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ template "fullname" . }}-esg-config-overrides"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: configuration
+data:
+{{ toYaml .Values.esgConfigOverrides | indent 2 }}

--- a/cluster/kubernetes/charts/templates/configuration/esg-config-overrides.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/esg-config-overrides.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: "{{ template "fullname" . }}-esg-config-overrides"
-  labels:
-{{ include "default-labels" . | indent 4 }}
-    component: configuration
-data:
-{{ toYaml .Values.esgConfigOverrides | indent 2 }}

--- a/cluster/kubernetes/charts/templates/configuration/esgcet-overrides.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/esgcet-overrides.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: "{{ template "fullname" . }}-esgcet-overrides"
-  labels:
-{{ include "default-labels" . | indent 4 }}
-    component: configuration
-data:
-{{ toYaml .Values.esgcetOverrides | indent 2 }}

--- a/cluster/kubernetes/charts/templates/configuration/esgcet-overrides.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/esgcet-overrides.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ template "fullname" . }}-esgcet-overrides"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: configuration
+data:
+{{ toYaml .Values.esgcetOverrides | indent 2 }}

--- a/cluster/kubernetes/charts/templates/configuration/hostcert.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/hostcert.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ template "fullname" . }}-hostcert"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: configuration
+data:
+  hostcert.crt: "{{ index .Values.certificates "hostcert.crt" | b64enc }}"
+  hostcert.key: "{{ index .Values.certificates "hostcert.key" | b64enc }}"

--- a/cluster/kubernetes/charts/templates/configuration/secrets.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ template "fullname" . }}-secrets"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: configuration
+data:
+{{- range $key, $value := .Values.secrets }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/configuration/slcs-ca.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/slcs-ca.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ template "fullname" . }}-slcs-ca"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: slcs
+data:
+  ca.crt: "{{ index .Values.certificates "slcsca.crt" | b64enc }}"
+  ca.key: "{{ index .Values.certificates "slcsca.key" | b64enc }}"

--- a/cluster/kubernetes/charts/templates/configuration/thredds-overrides.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/thredds-overrides.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: "{{ template "fullname" . }}-thredds-overrides"
-  labels:
-{{ include "default-labels" . | indent 4 }}
-    component: configuration
-data:
-{{ toYaml .Values.threddsOverrides | indent 2 }}

--- a/cluster/kubernetes/charts/templates/configuration/thredds-overrides.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/thredds-overrides.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ template "fullname" . }}-thredds-overrides"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: configuration
+data:
+{{ toYaml .Values.threddsOverrides | indent 2 }}

--- a/cluster/kubernetes/charts/templates/configuration/trust-bundle.yaml
+++ b/cluster/kubernetes/charts/templates/configuration/trust-bundle.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ template "fullname" . }}-trust-bundle"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: configuration
+data:
+  esg-trust-bundle.pem: |-
+{{ index .Values.certificates "esg-trust-bundle.pem" | indent 4 }}

--- a/cluster/kubernetes/charts/templates/idp-node/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/idp-node/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+        checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
     spec:
       initContainers:
         # Wait for security database to become available before starting

--- a/cluster/kubernetes/charts/templates/idp-node/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/idp-node/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
         checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
+        checksum/esg-config-overrides: {{ include (print $.Template.BasePath "/configuration/esg-config-overrides.yaml") . | sha256sum }}
     spec:
       initContainers:
         # Wait for security database to become available before starting
@@ -100,12 +101,18 @@ spec:
             - mountPath: /esg/certificates/esg-trust-bundle.pem
               name: trust-bundle
               subPath: esg-trust-bundle.pem
+              readOnly: true
             - mountPath: /esg/config/.esg_pg_pass
               name: esg-secrets
               subPath: security-database-password
+              readOnly: true
             - mountPath: /esg/config/.esgf_pass
               name: esg-secrets
               subPath: rootadmin-password
+              readOnly: true
+            - mountPath: /esg/config/.overrides
+              name: esg-config-overrides
+              readOnly: true
           resources:
 {{ toYaml .Values.idpNode.resources | indent 12 }}
       volumes:
@@ -115,3 +122,6 @@ spec:
         - name: esg-secrets
           secret:
             secretName: "{{ template "fullname" . }}-secrets"
+        - name: esg-config-overrides
+          configMap:
+            name: "{{ template "fullname" . }}-esg-config-overrides"

--- a/cluster/kubernetes/charts/templates/idp-node/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/idp-node/deployment.yaml
@@ -1,0 +1,116 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-idp-node"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: idp-node
+spec:
+  replicas: {{ .Values.idpNode.replicas }}
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: idp-node
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: idp-node
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
+        checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+        # Wait for security database to become available before starting
+        - name: ensure-postgres-security
+          image: "{{ .Values.postgresSecurity.image.repository }}:{{ .Values.postgresSecurity.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.postgresSecurity.image.pullPolicy | quote }}
+          env:
+            - name: PGHOST
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_HOST
+            - name: PGPORT
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_PORT
+            - name: PGUSER
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_USER
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "security-database-password"
+            - name: PGDATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_NAME
+          command:
+            # Try every 5 seconds for no longer than 10 mins
+            - bash
+            - -c
+            - |
+              for i in $(seq 120); do
+                sleep 5
+                echo "Attempt $i of 120"
+                if pg_isready; then exit 0; fi
+              done
+              exit 1
+      containers:
+        - name: idp-node
+          image: "{{ .Values.idpNode.image.repository }}:{{ .Values.idpNode.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.idpNode.image.pullPolicy | quote }}
+          ports:
+            - name: http
+              containerPort: 8080
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            httpGet:
+              path: /esgf-idp/
+              port: 8080
+              # This endpoint requires HTTPS, so simulate it
+              httpHeaders:
+                - name: Host
+                  value: "{{ .Values.hostname }}"
+                - name: X-Forwarded-Proto
+                  value: https
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          envFrom:
+            - configMapRef:
+                name: "{{ template "fullname" . }}-environment-common"
+          env:
+            - name: ESGF_DATABASE_PASSWORD_FILE
+              value: /esg/config/.esg_pg_pass
+          volumeMounts:
+            - mountPath: /esg/certificates/esg-trust-bundle.pem
+              name: trust-bundle
+              subPath: esg-trust-bundle.pem
+            - mountPath: /esg/config/.esg_pg_pass
+              name: esg-secrets
+              subPath: security-database-password
+            - mountPath: /esg/config/.esgf_pass
+              name: esg-secrets
+              subPath: rootadmin-password
+          resources:
+{{ toYaml .Values.idpNode.resources | indent 12 }}
+      volumes:
+        - name: trust-bundle
+          configMap:
+            name: "{{ template "fullname" . }}-trust-bundle"
+        - name: esg-secrets
+          secret:
+            secretName: "{{ template "fullname" . }}-secrets"

--- a/cluster/kubernetes/charts/templates/idp-node/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/idp-node/deployment.yaml
@@ -22,9 +22,27 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
         checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
-        checksum/esg-config-overrides: {{ include (print $.Template.BasePath "/configuration/esg-config-overrides.yaml") . | sha256sum }}
+        checksum/config-overrides: {{ include (print $.Template.BasePath "/configuration/config-overrides.yaml") . | sha256sum }}
     spec:
       initContainers:
+        # Unpack the required config overrides from the base64-encoded tarballs in the configmap
+        # This process is required because configmaps cannot contain nested directory structures
+        - name: unpack-config-overrides
+          image: busybox
+          command:
+            - "sh"
+            - "-c"
+            - |
+              set -eo pipefail
+              if [ -f /esg/tarballs/esg-config-overrides.tar.gz.b64 ]; then
+                  base64 -d /esg/tarballs/esg-config-overrides.tar.gz.b64 | tar -xz -C /esg/config
+              fi
+          volumeMounts:
+            - mountPath: /esg/config
+              name: esg-config-overrides
+            - mountPath: /esg/tarballs
+              name: override-tarballs
+              readOnly: true
         # Wait for security database to become available before starting
         - name: ensure-postgres-security
           image: "{{ .Values.postgresSecurity.image.repository }}:{{ .Values.postgresSecurity.image.tag }}"
@@ -123,5 +141,7 @@ spec:
           secret:
             secretName: "{{ template "fullname" . }}-secrets"
         - name: esg-config-overrides
+          emptyDir: {}
+        - name: override-tarballs
           configMap:
-            name: "{{ template "fullname" . }}-esg-config-overrides"
+            name: "{{ template "fullname" . }}-config-overrides"

--- a/cluster/kubernetes/charts/templates/idp-node/service.yaml
+++ b/cluster/kubernetes/charts/templates/idp-node/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-idp-node"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: idp-node
+spec:
+  ports:
+    - name: http
+      port: 8080
+  selector:
+    release: {{ .Release.Name }}
+    component: idp-node

--- a/cluster/kubernetes/charts/templates/index-node/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/index-node/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
         checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
+        checksum/esg-config-overrides: {{ include (print $.Template.BasePath "/configuration/esg-config-overrides.yaml") . | sha256sum }}
     spec:
       initContainers:
         # Make sure Solr is up before starting
@@ -66,9 +67,16 @@ spec:
             - mountPath: /esg/certificates/esg-trust-bundle.pem
               name: trust-bundle
               subPath: esg-trust-bundle.pem
+              readOnly: true
+            - mountPath: /esg/config/.overrides
+              name: esg-config-overrides
+              readOnly: true
           resources:
 {{ toYaml .Values.indexNode.resources | indent 12 }}
       volumes:
         - name: trust-bundle
           configMap:
             name: "{{ template "fullname" . }}-trust-bundle"
+        - name: esg-config-overrides
+          configMap:
+            name: "{{ template "fullname" . }}-esg-config-overrides"

--- a/cluster/kubernetes/charts/templates/index-node/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/index-node/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         component: index-node
       annotations:
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+        checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
     spec:
       initContainers:
         # Make sure Solr is up before starting

--- a/cluster/kubernetes/charts/templates/index-node/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/index-node/deployment.yaml
@@ -21,9 +21,27 @@ spec:
       annotations:
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
         checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
-        checksum/esg-config-overrides: {{ include (print $.Template.BasePath "/configuration/esg-config-overrides.yaml") . | sha256sum }}
+        checksum/config-overrides: {{ include (print $.Template.BasePath "/configuration/config-overrides.yaml") . | sha256sum }}
     spec:
       initContainers:
+        # Unpack the required config overrides from the base64-encoded tarballs in the configmap
+        # This process is required because configmaps cannot contain nested directory structures
+        - name: unpack-config-overrides
+          image: busybox
+          command:
+            - "sh"
+            - "-c"
+            - |
+              set -eo pipefail
+              if [ -f /esg/tarballs/esg-config-overrides.tar.gz.b64 ]; then
+                  base64 -d /esg/tarballs/esg-config-overrides.tar.gz.b64 | tar -xz -C /esg/config
+              fi
+          volumeMounts:
+            - mountPath: /esg/config
+              name: esg-config-overrides
+            - mountPath: /esg/tarballs
+              name: override-tarballs
+              readOnly: true
         # Make sure Solr is up before starting
         - name: ensure-solr-slave
           image: radial/busyboxplus:curl
@@ -62,7 +80,7 @@ spec:
                 name: "{{ template "fullname" . }}-environment-common"
           env:
             - name: ESGF_SOLR_SHARDS
-              value: "{{ template "fullname" . }}-solr-slave:8983/solr"
+              value: "{{ template "fullname" . }}-solr-slave:8983/solr{{ range .Values.solr.shards.shardList }},{{ template "fullname" $ }}-solr-{{ .name }}:8983/solr{{ end }}"
           volumeMounts:
             - mountPath: /esg/certificates/esg-trust-bundle.pem
               name: trust-bundle
@@ -78,5 +96,7 @@ spec:
           configMap:
             name: "{{ template "fullname" . }}-trust-bundle"
         - name: esg-config-overrides
+          emptyDir: {}
+        - name: override-tarballs
           configMap:
-            name: "{{ template "fullname" . }}-esg-config-overrides"
+            name: "{{ template "fullname" . }}-config-overrides"

--- a/cluster/kubernetes/charts/templates/index-node/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/index-node/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-index-node"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: index-node
+spec:
+  replicas: {{ .Values.indexNode.replicas }}
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: index-node
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: index-node
+      annotations:
+        checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+        # Make sure Solr is up before starting
+        - name: ensure-solr-slave
+          image: "{{ .Values.solr.image.repository }}:{{ .Values.solr.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.solr.image.pullPolicy | quote }}
+          args:
+            - "wait-for-solr.sh"
+            - "--max-attempts"
+            - "120"
+            - "--solr-url"
+            - "http://{{ template "fullname" . }}-solr-slave:8983"
+      containers:
+        - name: index-node
+          image: "{{ .Values.indexNode.image.repository }}:{{ .Values.indexNode.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.indexNode.image.pullPolicy | quote }}
+          ports:
+            - name: http
+              containerPort: 8080
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            httpGet:
+              path: /esg-search/search
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          envFrom:
+            - configMapRef:
+                name: "{{ template "fullname" . }}-environment-common"
+          env:
+            - name: ESGF_SOLR_SHARDS
+              value: "{{ template "fullname" . }}-solr-slave:8983/solr"
+          volumeMounts:
+            - mountPath: /esg/certificates/esg-trust-bundle.pem
+              name: trust-bundle
+              subPath: esg-trust-bundle.pem
+          resources:
+{{ toYaml .Values.indexNode.resources | indent 12 }}
+      volumes:
+        - name: trust-bundle
+          configMap:
+            name: "{{ template "fullname" . }}-trust-bundle"

--- a/cluster/kubernetes/charts/templates/index-node/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/index-node/deployment.yaml
@@ -24,14 +24,18 @@ spec:
       initContainers:
         # Make sure Solr is up before starting
         - name: ensure-solr-slave
-          image: "{{ .Values.solr.image.repository }}:{{ .Values.solr.image.tag }}"
-          imagePullPolicy: {{ default "" .Values.solr.image.pullPolicy | quote }}
-          args:
-            - "wait-for-solr.sh"
-            - "--max-attempts"
-            - "120"
-            - "--solr-url"
-            - "http://{{ template "fullname" . }}-solr-slave:8983"
+          image: radial/busyboxplus:curl
+          command:
+            # Try every 5 seconds for no longer than 10 mins
+            - sh
+            - -c
+            - |
+              for i in $(seq 120); do
+                sleep 5
+                echo "Attempt $i of 120"
+                if curl -k -m 1 -fsSL http://{{ template "fullname" . }}-solr-slave:8983/solr/admin/info/system?wt=json; then exit 0; fi
+              done
+              exit 1
       containers:
         - name: index-node
           image: "{{ .Values.indexNode.image.repository }}:{{ .Values.indexNode.image.tag }}"

--- a/cluster/kubernetes/charts/templates/index-node/service.yaml
+++ b/cluster/kubernetes/charts/templates/index-node/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-index-node"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: index-node
+spec:
+  ports:
+    - name: http
+      port: 8080
+  selector:
+    release: {{ .Release.Name }}
+    component: index-node

--- a/cluster/kubernetes/charts/templates/orp/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/orp/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         checksum/hostcert: {{ include (print $.Template.BasePath "/configuration/hostcert.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+        checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
     spec:
       containers:
         - name: orp

--- a/cluster/kubernetes/charts/templates/orp/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/orp/deployment.yaml
@@ -22,8 +22,27 @@ spec:
         checksum/hostcert: {{ include (print $.Template.BasePath "/configuration/hostcert.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
         checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
-        checksum/esg-config-overrides: {{ include (print $.Template.BasePath "/configuration/esg-config-overrides.yaml") . | sha256sum }}
+        checksum/config-overrides: {{ include (print $.Template.BasePath "/configuration/config-overrides.yaml") . | sha256sum }}
     spec:
+      initContainers:
+        # Unpack the required config overrides from the base64-encoded tarballs in the configmap
+        # This process is required because configmaps cannot contain nested directory structures
+        - name: unpack-config-overrides
+          image: busybox
+          command:
+            - "sh"
+            - "-c"
+            - |
+              set -eo pipefail
+              if [ -f /esg/tarballs/esg-config-overrides.tar.gz.b64 ]; then
+                  base64 -d /esg/tarballs/esg-config-overrides.tar.gz.b64 | tar -xz -C /esg/config
+              fi
+          volumeMounts:
+            - mountPath: /esg/config
+              name: esg-config-overrides
+            - mountPath: /esg/tarballs
+              name: override-tarballs
+              readOnly: true
       containers:
         - name: orp
           image: "{{ .Values.orp.image.repository }}:{{ .Values.orp.image.tag }}"
@@ -80,5 +99,7 @@ spec:
           configMap:
             name: "{{ template "fullname" . }}-trust-bundle"
         - name: esg-config-overrides
+          emptyDir: {}
+        - name: override-tarballs
           configMap:
-            name: "{{ template "fullname" . }}-esg-config-overrides"
+            name: "{{ template "fullname" . }}-config-overrides"

--- a/cluster/kubernetes/charts/templates/orp/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/orp/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         checksum/hostcert: {{ include (print $.Template.BasePath "/configuration/hostcert.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
         checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
+        checksum/esg-config-overrides: {{ include (print $.Template.BasePath "/configuration/esg-config-overrides.yaml") . | sha256sum }}
     spec:
       containers:
         - name: orp
@@ -61,9 +62,14 @@ spec:
           volumeMounts:
             - mountPath: /esg/certificates/hostcert
               name: hostcert
+              readOnly: true
             - mountPath: /esg/certificates/esg-trust-bundle.pem
               name: trust-bundle
               subPath: esg-trust-bundle.pem
+              readOnly: true
+            - mountPath: /esg/config/.overrides
+              name: esg-config-overrides
+              readOnly: true
           resources:
 {{ toYaml .Values.orp.resources | indent 12 }}
       volumes:
@@ -73,3 +79,6 @@ spec:
         - name: trust-bundle
           configMap:
             name: "{{ template "fullname" . }}-trust-bundle"
+        - name: esg-config-overrides
+          configMap:
+            name: "{{ template "fullname" . }}-esg-config-overrides"

--- a/cluster/kubernetes/charts/templates/orp/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/orp/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-orp"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: orp
+spec:
+  replicas: {{ .Values.orp.replicas }}
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: orp
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: orp
+      annotations:
+        checksum/hostcert: {{ include (print $.Template.BasePath "/configuration/hostcert.yaml") . | sha256sum }}
+        checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: orp
+          image: "{{ .Values.orp.image.repository }}:{{ .Values.orp.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.orp.image.pullPolicy | quote }}
+          ports:
+            - name: http
+              containerPort: 8080
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            httpGet:
+              path: /esg-orp/home.htm
+              port: 8080
+              # This endpoint requires HTTPS, so simulate it
+              httpHeaders:
+                - name: Host
+                  value: "{{ .Values.hostname }}"
+                - name: X-Forwarded-Proto
+                  value: https
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          envFrom:
+            - configMapRef:
+                name: "{{ template "fullname" . }}-environment-common"
+          env:
+            - name: ESGF_KEYSTORE_ALIAS
+              value: "{{ .Values.hostname }}"
+            - name: ESGF_SAML_CERT_FILE
+              value: /esg/certificates/hostcert/hostcert.crt
+            - name: ESGF_SAML_KEY_FILE
+              value: /esg/certificates/hostcert/hostcert.key
+          volumeMounts:
+            - mountPath: /esg/certificates/hostcert
+              name: hostcert
+            - mountPath: /esg/certificates/esg-trust-bundle.pem
+              name: trust-bundle
+              subPath: esg-trust-bundle.pem
+          resources:
+{{ toYaml .Values.orp.resources | indent 12 }}
+      volumes:
+        - name: hostcert
+          secret:
+            secretName: "{{ template "fullname" . }}-hostcert"
+        - name: trust-bundle
+          configMap:
+            name: "{{ template "fullname" . }}-trust-bundle"

--- a/cluster/kubernetes/charts/templates/orp/service.yaml
+++ b/cluster/kubernetes/charts/templates/orp/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-orp"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: orp
+spec:
+  ports:
+    - name: http
+      port: 8080
+  selector:
+    release: {{ .Release.Name }}
+    component: orp

--- a/cluster/kubernetes/charts/templates/postgres-esgcet/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/postgres-esgcet/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-postgres-esgcet"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: postgres-esgcet
+spec:
+  replicas: 1
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: postgres-esgcet
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: postgres-esgcet
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: postgres-esgcet
+          image: "{{ .Values.postgresEsgcet.image.repository }}:{{ .Values.postgresEsgcet.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.postgresEsgcet.image.pullPolicy | quote }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          env:
+            - name: POSTGRESQL_DATABASE
+              value: esgcet
+            - name: POSTGRESQL_USER
+              value: esgcet
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "esgcet-database-password"
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/pgsql/data
+          resources:
+{{ toYaml .Values.postgresEsgcet.resources | indent 12 }}
+      volumes:
+        - name: postgres-data
+{{- if .Values.postgresEsgcet.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: "{{ template "fullname" . }}-postgres-esgcet"
+{{- else }}
+          emptyDir: {}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/postgres-esgcet/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/postgres-esgcet/deployment.yaml
@@ -21,6 +21,10 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
     spec:
+      # Setting fsGroup for the pod allows some provisioners to chown mounted volumes to the given group
+      #   The postgres group is 26 inside our container
+      securityContext:
+        fsGroup: 26
       containers:
         - name: postgres-esgcet
           image: "{{ .Values.postgresEsgcet.image.repository }}:{{ .Values.postgresEsgcet.image.tag }}"

--- a/cluster/kubernetes/charts/templates/postgres-esgcet/pvc.yaml
+++ b/cluster/kubernetes/charts/templates/postgres-esgcet/pvc.yaml
@@ -15,6 +15,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.postgresEsgcet.persistence.size }}
+{{- if .Values.postgresEsgcet.persistence.selector }}
   selector:
 {{ toYaml .Values.postgresEsgcet.persistence.selector | indent 4 }}
+{{- end }}
 {{- end }}

--- a/cluster/kubernetes/charts/templates/postgres-esgcet/pvc.yaml
+++ b/cluster/kubernetes/charts/templates/postgres-esgcet/pvc.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.postgresEsgcet.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ template "fullname" . }}-postgres-esgcet"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: postgres-esgcet
+spec:
+  accessModes:
+    - ReadWriteOnce
+{{- if .Values.postgresEsgcet.persistence.storageClass }}
+  storageClassName: "{{ .Values.postgresEsgcet.persistence.storageClass }}"
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.postgresEsgcet.persistence.size }}
+  selector:
+{{ toYaml .Values.postgresEsgcet.persistence.selector | indent 4 }}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/postgres-esgcet/service.yaml
+++ b/cluster/kubernetes/charts/templates/postgres-esgcet/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-postgres-esgcet"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: postgres-esgcet
+spec:
+  ports:
+    - name: postgres
+      port: 5432
+  selector:
+    release: {{ .Release.Name }}
+    component: postgres-esgcet

--- a/cluster/kubernetes/charts/templates/postgres-security/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/postgres-security/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-postgres-security"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: postgres-security
+spec:
+  replicas: 1
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: postgres-security
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: postgres-security
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: postgres-security
+          image: "{{ .Values.postgresSecurity.image.repository }}:{{ .Values.postgresSecurity.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.postgresSecurity.image.pullPolicy | quote }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          env:
+            - name: POSTGRESQL_DATABASE
+              value: esgcet
+            - name: POSTGRESQL_USER
+              value: dbsuper
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "security-database-password"
+            - name: ESGF_ROOTADMIN_EMAIL
+              value: "CoG@{{ .Values.hostname }}"
+            - name: ESGF_ROOTADMIN_USERNAME
+              value: rootAdmin
+            - name: ESGF_ROOTADMIN_OPENID
+              value: https://{{ .Values.hostname }}/esgf-idp/openid/rootAdmin
+            - name: ESGF_ROOTADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "rootadmin-password"
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/pgsql/data
+          resources:
+{{ toYaml .Values.postgresSecurity.resources | indent 12 }}
+      volumes:
+        - name: postgres-data
+{{- if .Values.postgresSecurity.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: "{{ template "fullname" . }}-postgres-security"
+{{- else }}
+          emptyDir: {}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/postgres-security/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/postgres-security/deployment.yaml
@@ -21,6 +21,10 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
     spec:
+      # Setting fsGroup for the pod allows some provisioners to chown mounted volumes to the given group
+      #   The postgres group is 26 inside our container
+      securityContext:
+        fsGroup: 26
       containers:
         - name: postgres-security
           image: "{{ .Values.postgresSecurity.image.repository }}:{{ .Values.postgresSecurity.image.tag }}"

--- a/cluster/kubernetes/charts/templates/postgres-security/pvc.yaml
+++ b/cluster/kubernetes/charts/templates/postgres-security/pvc.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.postgresSecurity.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ template "fullname" . }}-postgres-security"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: postgres-security
+spec:
+  accessModes:
+    - ReadWriteOnce
+{{- if .Values.postgresSecurity.persistence.storageClass }}
+  storageClassName: "{{ .Values.postgresSecurity.persistence.storageClass }}"
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.postgresSecurity.persistence.size }}
+  selector:
+{{ toYaml .Values.postgresSecurity.persistence.selector | indent 4 }}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/postgres-security/pvc.yaml
+++ b/cluster/kubernetes/charts/templates/postgres-security/pvc.yaml
@@ -15,6 +15,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.postgresSecurity.persistence.size }}
+{{- if .Values.postgresSecurity.persistence.selector }}
   selector:
 {{ toYaml .Values.postgresSecurity.persistence.selector | indent 4 }}
+{{- end }}
 {{- end }}

--- a/cluster/kubernetes/charts/templates/postgres-security/service.yaml
+++ b/cluster/kubernetes/charts/templates/postgres-security/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-postgres-security"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: postgres-security
+spec:
+  ports:
+    - name: postgres
+      port: 5432
+  selector:
+    release: {{ .Release.Name }}
+    component: postgres-security

--- a/cluster/kubernetes/charts/templates/proxy/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/proxy/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-proxy"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: proxy
+spec:
+  replicas: {{ .Values.proxy.replicas }}
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: proxy
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: proxy
+      annotations:
+        checksum/hostcert: {{ include (print $.Template.BasePath "/configuration/hostcert.yaml") . | sha256sum }}
+        checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: proxy
+          image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.proxy.image.pullPolicy | quote }}
+          ports:
+            - name: http
+              containerPort: 80
+            - name: https
+              containerPort: 443
+          env:
+            - name: ESGF_HOSTNAME
+              value: "{{ .Values.hostname }}"
+            - name: ESGF_SOLR_UPSTREAM
+              value: "http://{{ template "fullname" . }}-solr-slave.{{ .Release.Namespace }}.svc.cluster.local:8983"
+            - name: ESGF_INDEX_NODE_UPSTREAM
+              value: "http://{{ template "fullname" . }}-index-node.{{ .Release.Namespace }}.svc.cluster.local:8080"
+            - name: ESGF_TDS_UPSTREAM
+              value: "http://{{ template "fullname" . }}-tds.{{ .Release.Namespace }}.svc.cluster.local:8080"
+            - name: ESGF_COG_UPSTREAM
+              value: "http://{{ template "fullname" . }}-cog.{{ .Release.Namespace }}.svc.cluster.local:8000"
+            - name: ESGF_ORP_UPSTREAM
+              value: "http://{{ template "fullname" . }}-orp.{{ .Release.Namespace }}.svc.cluster.local:8080"
+            - name: ESGF_IDP_UPSTREAM
+              value: "http://{{ template "fullname" . }}-idp-node.{{ .Release.Namespace }}.svc.cluster.local:8080"
+            - name: ESGF_SLCS_UPSTREAM
+              value: "http://{{ template "fullname" . }}-slcs.{{ .Release.Namespace }}.svc.cluster.local:8000"
+            - name: ESGF_AUTH_UPSTREAM
+              value: "http://{{ template "fullname" . }}-auth.{{ .Release.Namespace }}.svc.cluster.local:8000"
+          volumeMounts:
+            - mountPath: /etc/nginx/ssl
+              name: hostcert
+            - mountPath: /esg/certificates/esg-trust-bundle.pem
+              name: trust-bundle
+              subPath: esg-trust-bundle.pem
+          resources:
+{{ toYaml .Values.proxy.resources | indent 12 }}
+      volumes:
+        - name: hostcert
+          secret:
+            secretName: "{{ template "fullname" . }}-hostcert"
+        - name: trust-bundle
+          configMap:
+            name: "{{ template "fullname" . }}-trust-bundle"

--- a/cluster/kubernetes/charts/templates/proxy/ingress.yaml
+++ b/cluster/kubernetes/charts/templates/proxy/ingress.yaml
@@ -1,0 +1,28 @@
+{{- if (and .Values.proxy.ingress.enabled (eq .Values.proxy.ingress.mode "kubernetes")) }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "{{ template "fullname" . }}-proxy"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: proxy
+  annotations:
+    # This ingress is specifically for the Nginx ingress controller
+    # It will be ignored by all other ingress controllers, and so can co-exist
+    # with similar ingresses for other controllers
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+spec:
+  rules:
+    - host: "{{ .Values.hostname }}"
+      http:
+        paths:
+          - backend:
+              serviceName: "{{ template "fullname" . }}-proxy"
+              servicePort: 443
+  tls:
+    - hosts:
+      - "{{ .Values.hostname }}"
+{{- end }}

--- a/cluster/kubernetes/charts/templates/proxy/route.yaml
+++ b/cluster/kubernetes/charts/templates/proxy/route.yaml
@@ -1,0 +1,17 @@
+{{- if (and .Values.proxy.ingress.enabled (eq .Values.proxy.ingress.mode "openshift")) }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: "{{ template "fullname" . }}-proxy"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: proxy
+spec:
+  host: "{{ .Values.hostname }}"
+  to:
+    kind: Service
+    name: "{{ template "fullname" . }}-proxy"
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: passthrough
+{{- end }}

--- a/cluster/kubernetes/charts/templates/proxy/service.yaml
+++ b/cluster/kubernetes/charts/templates/proxy/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-proxy"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: proxy
+spec:
+  ports:
+    - name: https
+      port: 443
+  selector:
+    release: {{ .Release.Name }}
+    component: proxy

--- a/cluster/kubernetes/charts/templates/publisher/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/publisher/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+        checksum/esgcet-overrides: {{ include (print $.Template.BasePath "/configuration/esgcet-overrides.yaml") . | sha256sum }}
     spec:
       # Setting fsGroup for the pod allows some provisioners to chown mounted volumes to the given group
       #   The publish group is 1001 inside the container
@@ -122,6 +123,10 @@ spec:
             - mountPath: /esg/certificates/esg-trust-bundle.pem
               name: trust-bundle
               subPath: esg-trust-bundle.pem
+              readOnly: true
+            - mountPath: /esg/config/esgcet/.overrides
+              name: esgcet-overrides
+              readOnly: true
           resources:
 {{ toYaml .Values.publisher.resources | indent 12 }}
       volumes:
@@ -134,3 +139,6 @@ spec:
         - name: trust-bundle
           configMap:
             name: "{{ template "fullname" . }}-trust-bundle"
+        - name: esgcet-overrides
+          configMap:
+            name: "{{ template "fullname" . }}-esgcet-overrides"

--- a/cluster/kubernetes/charts/templates/publisher/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/publisher/deployment.yaml
@@ -23,13 +23,31 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
-        checksum/esgcet-overrides: {{ include (print $.Template.BasePath "/configuration/esgcet-overrides.yaml") . | sha256sum }}
+        checksum/config-overrides: {{ include (print $.Template.BasePath "/configuration/config-overrides.yaml") . | sha256sum }}
     spec:
       # Setting fsGroup for the pod allows some provisioners to chown mounted volumes to the given group
       #   The publish group is 1001 inside the container
       securityContext:
         fsGroup: 1001
       initContainers:
+        # Unpack the required config overrides from the base64-encoded tarballs in the configmap
+        # This process is required because configmaps cannot contain nested directory structures
+        - name: unpack-config-overrides
+          image: busybox
+          command:
+            - "sh"
+            - "-c"
+            - |
+              set -eo pipefail
+              if [ -f /esg/tarballs/publisher-overrides.tar.gz.b64 ]; then
+                  base64 -d /esg/tarballs/publisher-overrides.tar.gz.b64 | tar -xz -C /esg/publisher
+              fi
+          volumeMounts:
+            - mountPath: /esg/publisher
+              name: esgcet-overrides
+            - mountPath: /esg/tarballs
+              name: override-tarballs
+              readOnly: true
         # Wait for postgres-esgcet to become available before starting
         - name: ensure-postgres-esgcet
           image: "{{ .Values.postgresEsgcet.image.repository }}:{{ .Values.postgresEsgcet.image.tag }}"
@@ -140,5 +158,7 @@ spec:
           configMap:
             name: "{{ template "fullname" . }}-trust-bundle"
         - name: esgcet-overrides
+          emptyDir: {}
+        - name: override-tarballs
           configMap:
-            name: "{{ template "fullname" . }}-esgcet-overrides"
+            name: "{{ template "fullname" . }}-config-overrides"

--- a/cluster/kubernetes/charts/templates/publisher/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/publisher/deployment.yaml
@@ -115,15 +115,15 @@ spec:
             - name: ESGF_DATABASE_NAME
               value: esgcet
             - name: ESGF_HESSIAN_METADATA_URL
-              value: "https://{{ .Values.hostname }}/esgcet/remote/hessian/guest/remoteMetadataService"
+              value: {{ default (printf "https://%s/esgcet/remote/hessian/guest/remoteMetadataService" .Values.hostname) .Values.publisher.environment.ESGF_HESSIAN_METADATA_URL | quote }}
             - name: ESGF_HESSIAN_URL
-              value: "https://{{ .Values.hostname }}/esg-search/remote/secure/client-cert/hessian/publishingService"
+              value: {{ default (printf "https://%s/esg-search/remote/secure/client-cert/hessian/publishingService" .Values.hostname) .Values.publisher.environment.ESGF_HESSIAN_URL | quote }}
             - name: ESGF_TDS_CATALOG_URL
-              value: "https://{{ .Values.hostname }}/thredds/catalog/esgcet"
+              value: {{ default (printf "https://%s/thredds/catalog/esgcet" .Values.hostname) .Values.publisher.environment.ESGF_TDS_CATALOG_URL | quote }}
             - name: ESGF_TDS_REINIT_URL
-              value: "https://{{ .Values.hostname }}/thredds/admin/debug?Catalogs/recheck"
+              value: {{ default (printf "https://%s/thredds/admin/debug?Catalogs/recheck" .Values.hostname) .Values.publisher.environment.ESGF_TDS_REINIT_URL | quote }}
             - name: ESGF_TDS_REINIT_ERROR_URL
-              value: "https://{{ .Values.hostname }}/thredds/admin/content/logs/catalogInit.log"
+              value: {{ default (printf "https://%s/thredds/admin/content/logs/catalogInit.log" .Values.hostname) .Values.publisher.environment.ESGF_TDS_REINIT_ERROR_URL | quote }}
             - name: ESGF_TDS_USERNAME
               value: rootAdmin
             - name: ESGF_TDS_PASSWORD
@@ -132,7 +132,7 @@ spec:
                   name: "{{ template "fullname" . }}-secrets"
                   key: "rootadmin-password"
             - name: ESGF_SLCS_CERTIFICATE_URL
-              value: "https://{{ .Values.hostname }}/esgf-slcs/onlineca/certificate/"
+              value: {{ default (printf "https://%s/esgf-slcs/onlineca/certificate/" .Values.hostname) .Values.publisher.environment.ESGF_SLCS_CERTIFICATE_URL | quote }}
           volumeMounts:
             - mountPath: /esg/content/thredds/esgcet
               name: tds-content

--- a/cluster/kubernetes/charts/templates/publisher/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/publisher/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
     spec:
+      # Setting fsGroup for the pod allows some provisioners to chown mounted volumes to the given group
+      #   The publish group is 1001 inside the container
+      securityContext:
+        fsGroup: 1001
       initContainers:
         # Wait for postgres-esgcet to become available before starting
         - name: ensure-postgres-esgcet
@@ -73,7 +77,7 @@ spec:
           image: "{{ .Values.publisher.image.repository }}:{{ .Values.publisher.image.tag }}"
           imagePullPolicy: {{ default "" .Values.publisher.image.pullPolicy | quote }}
           # Just sit and wait for somebody to connect via exec
-          args:
+          command:
             - "bash"
             - "-c"
             - "sleep infinity"

--- a/cluster/kubernetes/charts/templates/publisher/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/publisher/deployment.yaml
@@ -1,0 +1,132 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-publisher"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: publisher
+spec:
+  # Every time the publisher deployment is rolled out, the number of replicas is set to zero
+  # To perform a publish, scale up the deployment to 1 replica, perform the publish and scale back down to 0
+  replicas: 0
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: publisher
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: publisher
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
+        checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+        # Wait for postgres-esgcet to become available before starting
+        - name: ensure-postgres-esgcet
+          image: "{{ .Values.postgresEsgcet.image.repository }}:{{ .Values.postgresEsgcet.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.postgresEsgcet.image.pullPolicy | quote }}
+          env:
+            - name: PGHOST
+              value: "{{ template "fullname" . }}-postgres-esgcet"
+            - name: PGPORT
+              value: "5432"
+            - name: PGUSER
+              value: esgcet
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "esgcet-database-password"
+            - name: PGDATABASE
+              value: esgcet
+          command:
+            # Try every 5 seconds for no longer than 10 mins
+            - bash
+            - -c
+            - |
+              for i in $(seq 120); do
+                sleep 5
+                echo "Attempt $i of 120"
+                if pg_isready; then exit 0; fi
+              done
+              exit 1
+        # Ensure the index node is up before starting
+        - name: ensure-index-node
+          image: radial/busyboxplus:curl
+          command:
+            # Try every 5 seconds for no longer than 10 mins
+            - sh
+            - -c
+            - |
+              for i in $(seq 120); do
+                sleep 5
+                echo "Attempt $i of 120"
+                if curl -k -m 1 -fsSL https://{{ .Values.hostname }}/esg-search/search; then exit 0; fi
+              done
+              exit 1
+      containers:
+        - name: publisher
+          image: "{{ .Values.publisher.image.repository }}:{{ .Values.publisher.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.publisher.image.pullPolicy | quote }}
+          # Just sit and wait for somebody to connect via exec
+          args:
+            - "bash"
+            - "-c"
+            - "sleep infinity"
+          env:
+            - name: ESGF_DATABASE_HOST
+              value: "{{ template "fullname" . }}-postgres-esgcet"
+            - name: ESGF_DATABASE_PORT
+              value: "5432"
+            - name: ESGF_DATABASE_USER
+              value: esgcet
+            - name: ESGF_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "esgcet-database-password"
+            - name: ESGF_DATABASE_NAME
+              value: esgcet
+            - name: ESGF_HESSIAN_METADATA_URL
+              value: "https://{{ .Values.hostname }}/esgcet/remote/hessian/guest/remoteMetadataService"
+            - name: ESGF_HESSIAN_URL
+              value: "https://{{ .Values.hostname }}/esg-search/remote/secure/client-cert/hessian/publishingService"
+            - name: ESGF_TDS_CATALOG_URL
+              value: "https://{{ .Values.hostname }}/thredds/catalog/esgcet"
+            - name: ESGF_TDS_REINIT_URL
+              value: "https://{{ .Values.hostname }}/thredds/admin/debug?Catalogs/recheck"
+            - name: ESGF_TDS_REINIT_ERROR_URL
+              value: "https://{{ .Values.hostname }}/thredds/admin/content/logs/catalogInit.log"
+            - name: ESGF_TDS_USERNAME
+              value: rootAdmin
+            - name: ESGF_TDS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "rootadmin-password"
+            - name: ESGF_SLCS_CERTIFICATE_URL
+              value: "https://{{ .Values.hostname }}/esgf-slcs/onlineca/certificate/"
+          volumeMounts:
+            - mountPath: /esg/content/thredds/esgcet
+              name: tds-content
+            - mountPath: /esg/data
+              name: tds-data
+            - mountPath: /esg/certificates/esg-trust-bundle.pem
+              name: trust-bundle
+              subPath: esg-trust-bundle.pem
+          resources:
+{{ toYaml .Values.publisher.resources | indent 12 }}
+      volumes:
+        - name: tds-content
+          persistentVolumeClaim:
+            claimName: "{{ template "fullname" . }}-tds-content"
+        - name: tds-data
+          persistentVolumeClaim:
+            claimName: "{{ template "fullname" . }}-tds-data"
+        - name: trust-bundle
+          configMap:
+            name: "{{ template "fullname" . }}-trust-bundle"

--- a/cluster/kubernetes/charts/templates/slcs/deployment-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/slcs/deployment-postgres.yaml
@@ -1,0 +1,67 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-postgres-slcs"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: slcs
+    slcs-role: database
+spec:
+  replicas: 1
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: slcs
+      slcs-role: database
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: slcs
+        slcs-role: database
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: postgres-slcs
+          image: "{{ .Values.slcs.postgres.image.repository }}:{{ .Values.slcs.postgres.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.slcs.postgres.image.pullPolicy | quote }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          env:
+            - name: POSTGRESQL_DATABASE
+              value: slcs
+            - name: POSTGRESQL_USER
+              value: slcsuser
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "slcs-database-password"
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/pgsql/data
+          resources:
+{{ toYaml .Values.slcs.postgres.resources | indent 12 }}
+      volumes:
+        - name: postgres-data
+{{- if .Values.slcs.postgres.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: "{{ template "fullname" . }}-postgres-slcs"
+{{- else }}
+          emptyDir: {}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/slcs/deployment-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/slcs/deployment-postgres.yaml
@@ -24,6 +24,10 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
     spec:
+      # Setting fsGroup for the pod allows some provisioners to chown mounted volumes to the given group
+      #   The postgres group is 26 inside the container
+      securityContext:
+        fsGroup: 26
       containers:
         - name: postgres-slcs
           image: "{{ .Values.slcs.postgres.image.repository }}:{{ .Values.slcs.postgres.image.tag }}"

--- a/cluster/kubernetes/charts/templates/slcs/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/slcs/deployment.yaml
@@ -1,0 +1,220 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-slcs"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: slcs
+    slcs-role: frontend
+spec:
+  replicas: {{ .Values.slcs.replicas }}
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: slcs
+      slcs-role: frontend
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: slcs
+        slcs-role: frontend
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
+        checksum/slcs-ca: {{ include (print $.Template.BasePath "/configuration/slcs-ca.yaml") . | sha256sum }}
+        checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+        # Wait for databases to become available before starting
+        - name: ensure-postgres-slcs
+          image: "{{ .Values.slcs.postgres.image.repository }}:{{ .Values.slcs.postgres.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.slcs.postgres.image.pullPolicy | quote }}
+          env:
+            - name: PGHOST
+              value: "{{ template "fullname" . }}-postgres-slcs"
+            - name: PGPORT
+              value: "5432"
+            - name: PGUSER
+              value: slcsuser
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "slcs-database-password"
+            - name: PGDATABASE
+              value: slcs
+          command:
+            # Try every 5 seconds for no longer than 10 mins
+            - bash
+            - -c
+            - |
+              for i in $(seq 120); do
+                sleep 5
+                echo "Attempt $i of 120"
+                if pg_isready; then exit 0; fi
+              done
+              exit 1
+        - name: ensure-postgres-security
+          image: "{{ .Values.slcs.postgres.image.repository }}:{{ .Values.slcs.postgres.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.slcs.postgres.image.pullPolicy | quote }}
+          env:
+            - name: PGHOST
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_HOST
+            - name: PGPORT
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_PORT
+            - name: PGUSER
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_USER
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "security-database-password"
+            - name: PGDATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_NAME
+          command:
+            # Try every 5 seconds for no longer than 10 mins
+            - bash
+            - -c
+            - |
+              for i in $(seq 120); do
+                sleep 5
+                echo "Attempt $i of 120"
+                if pg_isready; then exit 0; fi
+              done
+              exit 1
+      containers:
+        - name: slcs
+          image: "{{ .Values.slcs.image.repository }}:{{ .Values.slcs.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.slcs.image.pullPolicy | quote }}
+          ports:
+            - name: http
+              containerPort: 8000
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            httpGet:
+              path: /esgf-slcs
+              port: 8000
+              # The ALLOWED_HOSTS setting means that the app will only accept
+              # requests from the correct host
+              httpHeaders:
+                - name: Host
+                  value: "{{ .Values.hostname }}"
+                - name: X-Forwarded-Host
+                  value: "{{ .Values.hostname }}"
+                - name: X-Forwarded-Proto
+                  value: https
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          env:
+            # Generic Django settings
+            - name: SCRIPT_NAME
+              value: /esgf-slcs
+            - name: DJANGO_ALLOWED_HOSTS
+              value: "{{ .Values.hostname }}"
+            - name: DJANGO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "slcs-secret-key"
+            # SLCS database
+            - name: DJANGO_DATABASE_DEFAULT_ENGINE
+              value: django.db.backends.postgresql
+            - name: DJANGO_DATABASE_DEFAULT_HOST
+              value: "{{ template "fullname" . }}-postgres-slcs"
+            - name: DJANGO_DATABASE_DEFAULT_PORT
+              value: "5432"
+            - name: DJANGO_DATABASE_DEFAULT_USER
+              value: slcsuser
+            - name: DJANGO_DATABASE_DEFAULT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "slcs-database-password"
+            - name: DJANGO_DATABASE_DEFAULT_NAME
+              value: slcs
+            # ESGF User database
+            - name: DJANGO_DATABASE_USERDB_ENGINE
+              value: django.db.backends.postgresql
+            - name: DJANGO_DATABASE_USERDB_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_HOST
+            - name: DJANGO_DATABASE_USERDB_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_PORT
+            - name: DJANGO_DATABASE_USERDB_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_USER
+            - name: DJANGO_DATABASE_USERDB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "security-database-password"
+            - name: DJANGO_DATABASE_USERDB_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ template "fullname" . }}-environment-common"
+                  key: ESGF_DATABASE_NAME
+            # Make the rootAdmin account a superuser
+            - name: DJANGO_CREATE_SUPERUSER
+              value: "1"
+            - name: DJANGO_SUPERUSER_USERNAME
+              value: "rootAdmin"
+            - name: DJANGO_SUPERUSER_EMAIL
+              value: "CoG@{{ .Values.hostname }}"
+            # Other SLCS-specific settings
+            - name: ESGF_SLCS_URL
+              value: "https://{{ .Values.hostname }}/esgf-slcs"
+            - name: ESGF_SLCS_BASIC_AUTH_REALM
+              value: "{{ .Values.hostname }}"
+            - name: ONLINECA_SUBJECT_NAME_TEMPLATE
+              value: "/DC=esgf/CN={user}"
+            - name: ONLINECA_CERT_PATH
+              value: /esg/certificates/slcsca/ca.crt
+            - name: ONLINECA_KEY_PATH
+              value: /esg/certificates/slcsca/ca.key
+            - name: ONLINECA_TRUSTROOTS_DIR
+              value: /esg/certificates/slcsca/trustroots
+          volumeMounts:
+            - mountPath: /esg/certificates/slcsca
+              name: slcsca
+            - mountPath: /esg/certificates/slcsca-trustroots
+              name: trustroots
+            - mountPath: /esg/certificates/esg-trust-bundle.pem
+              name: trust-bundle
+              subPath: esg-trust-bundle.pem
+          resources:
+{{ toYaml .Values.slcs.resources | indent 12 }}
+      volumes:
+        - name: slcsca
+          secret:
+            secretName: "{{ template "fullname" . }}-slcs-ca"
+        - name: trustroots
+          emptyDir: {}
+        - name: trust-bundle
+          configMap:
+            name: "{{ template "fullname" . }}-trust-bundle"

--- a/cluster/kubernetes/charts/templates/slcs/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/slcs/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/slcs-ca: {{ include (print $.Template.BasePath "/configuration/slcs-ca.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+        checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
     spec:
       initContainers:
         # Wait for databases to become available before starting

--- a/cluster/kubernetes/charts/templates/slcs/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/slcs/deployment.yaml
@@ -193,7 +193,7 @@ spec:
             - name: ESGF_SLCS_BASIC_AUTH_REALM
               value: "{{ .Values.hostname }}"
             - name: ONLINECA_SUBJECT_NAME_TEMPLATE
-              value: "/DC=esgf/CN={user}"
+              value: {{ default "/DC=esgf/CN={user}" .Values.slcs.environment.ONLINECA_SUBJECT_NAME_TEMPLATE | quote }}
             - name: ONLINECA_CERT_PATH
               value: /esg/certificates/slcsca/ca.crt
             - name: ONLINECA_KEY_PATH

--- a/cluster/kubernetes/charts/templates/slcs/pvc-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/slcs/pvc-postgres.yaml
@@ -16,6 +16,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.slcs.postgres.persistence.size }}
+{{- if .Values.slcs.postgres.persistence.selector }}
   selector:
 {{ toYaml .Values.slcs.postgres.persistence.selector | indent 4 }}
+{{- end }}
 {{- end }}

--- a/cluster/kubernetes/charts/templates/slcs/pvc-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/slcs/pvc-postgres.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.slcs.postgres.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ template "fullname" . }}-postgres-slcs"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: slcs
+    slcs-role: database
+spec:
+  accessModes:
+    - ReadWriteOnce
+{{- if .Values.slcs.postgres.persistence.storageClass }}
+  storageClassName: "{{ .Values.slcs.postgres.persistence.storageClass }}"
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.slcs.postgres.persistence.size }}
+  selector:
+{{ toYaml .Values.slcs.postgres.persistence.selector | indent 4 }}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/slcs/service-postgres.yaml
+++ b/cluster/kubernetes/charts/templates/slcs/service-postgres.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-postgres-slcs"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: slcs
+    slcs-role: database
+spec:
+  ports:
+    - name: postgres
+      port: 5432
+  selector:
+    release: {{ .Release.Name }}
+    component: slcs
+    slcs-role: database

--- a/cluster/kubernetes/charts/templates/slcs/service.yaml
+++ b/cluster/kubernetes/charts/templates/slcs/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-slcs"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: slcs
+    slcs-role: frontend
+spec:
+  ports:
+    - name: http
+      port: 8000
+  selector:
+    release: {{ .Release.Name }}
+    component: slcs
+    slcs-role: frontend

--- a/cluster/kubernetes/charts/templates/solr/master-deployment.yaml
+++ b/cluster/kubernetes/charts/templates/solr/master-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-solr-master"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: solr
+    solr-role: master
+spec:
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: solr
+      solr-role: master
+  replicas: 1
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: solr
+        solr-role: master
+    spec:
+      containers:
+        - name: solr-master
+          image: "{{ .Values.solr.image.repository }}:{{ .Values.solr.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.solr.image.pullPolicy | quote }}
+          ports:
+            - name: solr
+              containerPort: 8983
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            httpGet:
+              path: /solr/admin/info/system?wt=json
+              port: 8983
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          env:
+            - name: ESGF_SOLR_ROLE
+              value: master
+          resources:
+{{ toYaml .Values.solr.master.resources | indent 12 }}
+          volumeMounts:
+            - name: solr-home
+              mountPath: /esg/solr-home
+      volumes:
+        - name: solr-home
+{{- if .Values.solr.master.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: "{{ template "fullname" . }}-solr-master"
+{{- else }}
+          emptyDir: {}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/solr/master-deployment.yaml
+++ b/cluster/kubernetes/charts/templates/solr/master-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         component: solr
         solr-role: master
     spec:
+      # Setting fsGroup for the pod allows some provisioners to chown mounted volumes to the given group
+      #   The solr group is 8983 inside the container
+      securityContext:
+        fsGroup: 8983
       containers:
         - name: solr-master
           image: "{{ .Values.solr.image.repository }}:{{ .Values.solr.image.tag }}"

--- a/cluster/kubernetes/charts/templates/solr/master-pvc.yaml
+++ b/cluster/kubernetes/charts/templates/solr/master-pvc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.solr.master.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ template "fullname" . }}-solr-master"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: solr
+    solr-role: master
+spec:
+  accessModes:
+    - ReadWriteOnce
+{{- if .Values.solr.master.persistence.storageClass }}
+  storageClassName: "{{ .Values.solr.master.persistence.storageClass }}"
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.solr.master.persistence.size }}
+  selector:
+{{ toYaml .Values.solr.master.persistence.selector | indent 4 }}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/solr/master-pvc.yaml
+++ b/cluster/kubernetes/charts/templates/solr/master-pvc.yaml
@@ -16,6 +16,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.solr.master.persistence.size }}
+{{- if .Values.solr.master.persistence.selector }}
   selector:
 {{ toYaml .Values.solr.master.persistence.selector | indent 4 }}
+{{- end }}
 {{- end }}

--- a/cluster/kubernetes/charts/templates/solr/master-service.yaml
+++ b/cluster/kubernetes/charts/templates/solr/master-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-solr-master"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: solr
+    solr-role: master
+spec:
+  ports:
+    - name: solr
+      port: 8983
+  selector:
+    release: {{ .Release.Name }}
+    component: solr
+    solr-role: master

--- a/cluster/kubernetes/charts/templates/solr/shards-deployment.yaml
+++ b/cluster/kubernetes/charts/templates/solr/shards-deployment.yaml
@@ -1,31 +1,31 @@
-{{- range $shard := .Values.solr.shards.shardList }}
+{{- range .Values.solr.shards.shardList }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: "{{ template "fullname" . }}-solr-{{ $shard.name }}"
+  name: "{{ template "fullname" $ }}-solr-{{ .name }}"
   labels:
-{{ include "default-labels" . | indent 4 }}
+{{ include "default-labels" $ | indent 4 }}
     component: solr
     solr-role: shard
-    shard-name: "{{ $shard.name }}"
+    shard-name: "{{ .name }}"
 spec:
   # Select pods on release and component only, rather than all labels
   # This means that the selector will match all pods from all versions of the chart when upgrading
   selector:
     matchLabels:
-      release: {{ .Release.Name }}
+      release: {{ $.Release.Name }}
       component: solr
       solr-role: shard
-      shard-name: "{{ $shard.name }}"
+      shard-name: "{{ .name }}"
   replicas: 1
   template:
     metadata:
       labels:
-{{ include "default-labels" . | indent 8 }}
+{{ include "default-labels" $ | indent 8 }}
         component: solr
         solr-role: shard
-        shard-name: "{{ $shard.name }}"
+        shard-name: "{{ .name }}"
     spec:
       # Setting fsGroup for the pod allows some provisioners to chown mounted volumes to the given group
       #   The solr group is 8983 inside the container
@@ -33,8 +33,8 @@ spec:
         fsGroup: 8983
       containers:
         - name: solr
-          image: "{{ .Values.solr.image.repository }}:{{ .Values.solr.image.tag }}"
-          imagePullPolicy: {{ default "" .Values.solr.image.pullPolicy | quote }}
+          image: "{{ $.Values.solr.image.repository }}:{{ $.Values.solr.image.tag }}"
+          imagePullPolicy: {{ default "" $.Values.solr.image.pullPolicy | quote }}
           ports:
             - name: solr
               containerPort: 8983
@@ -52,21 +52,21 @@ spec:
             initialDelaySeconds: 600
           env:
             - name: ESGF_SOLR_MASTER_URL
-              value: "{{ $shard.url }}"
-            {{- if hasKey $shard "replicationInterval" }}
+              value: "{{ .url }}"
+            {{- if hasKey . "replicationInterval" }}
             - name: ESGF_SOLR_REPLICATION_INTERVAL
-              value: "{{ $shard.replicationInterval }}"
+              value: "{{ .replicationInterval }}"
             {{- end }}
           resources:
-{{ toYaml .Values.solr.shards.resources | indent 12 }}
+{{ toYaml $.Values.solr.shards.resources | indent 12 }}
           volumeMounts:
             - name: solr-home
               mountPath: /esg/solr-home
       volumes:
         - name: solr-home
-{{- if .Values.solr.shards.persistence.enabled }}
+{{- if $.Values.solr.shards.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: "{{ template "fullname" . }}-solr-{{ $shard.name }}"
+            claimName: "{{ template "fullname" $ }}-solr-{{ .name }}"
 {{- else }}
           emptyDir: {}
 {{- end }}

--- a/cluster/kubernetes/charts/templates/solr/shards-deployment.yaml
+++ b/cluster/kubernetes/charts/templates/solr/shards-deployment.yaml
@@ -1,0 +1,73 @@
+{{- range $shard := .Values.solr.shards.shardList }}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-solr-{{ $shard.name }}"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: solr
+    solr-role: shard
+    shard-name: "{{ $shard.name }}"
+spec:
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: solr
+      solr-role: shard
+      shard-name: "{{ $shard.name }}"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: solr
+        solr-role: shard
+        shard-name: "{{ $shard.name }}"
+    spec:
+      # Setting fsGroup for the pod allows some provisioners to chown mounted volumes to the given group
+      #   The solr group is 8983 inside the container
+      securityContext:
+        fsGroup: 8983
+      containers:
+        - name: solr
+          image: "{{ .Values.solr.image.repository }}:{{ .Values.solr.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.solr.image.pullPolicy | quote }}
+          ports:
+            - name: solr
+              containerPort: 8983
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            httpGet:
+              path: /solr/admin/info/system?wt=json
+              port: 8983
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          env:
+            - name: ESGF_SOLR_MASTER_URL
+              value: "{{ $shard.url }}"
+            {{- if hasKey $shard "replicationInterval" }}
+            - name: ESGF_SOLR_REPLICATION_INTERVAL
+              value: "{{ $shard.replicationInterval }}"
+            {{- end }}
+          resources:
+{{ toYaml .Values.solr.shards.resources | indent 12 }}
+          volumeMounts:
+            - name: solr-home
+              mountPath: /esg/solr-home
+      volumes:
+        - name: solr-home
+{{- if .Values.solr.shards.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: "{{ template "fullname" . }}-solr-{{ $shard.name }}"
+{{- else }}
+          emptyDir: {}
+{{- end }}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/solr/shards-pvc.yaml
+++ b/cluster/kubernetes/charts/templates/solr/shards-pvc.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.solr.shards.persistence.enabled }}
+{{- range $shard := .Values.solr.shards.shardList }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ template "fullname" . }}-solr-{{ $shard.name }}"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: solr
+    solr-role: shard
+    shard-name: "{{ $shard.name }}"
+spec:
+  accessModes:
+    - ReadWriteOnce
+{{- if .Values.solr.shards.persistence.storageClass }}
+  storageClassName: "{{ .Values.solr.shards.persistence.storageClass }}"
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.solr.shards.persistence.size }}
+{{- if .Values.solr.shards.persistence.selector }}
+  selector:
+{{ toYaml .Values.solr.shards.persistence.selector | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/solr/shards-pvc.yaml
+++ b/cluster/kubernetes/charts/templates/solr/shards-pvc.yaml
@@ -1,27 +1,27 @@
 {{- if .Values.solr.shards.persistence.enabled }}
-{{- range $shard := .Values.solr.shards.shardList }}
+{{- range .Values.solr.shards.shardList }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: "{{ template "fullname" . }}-solr-{{ $shard.name }}"
+  name: "{{ template "fullname" $ }}-solr-{{ .name }}"
   labels:
-{{ include "default-labels" . | indent 4 }}
+{{ include "default-labels" $ | indent 4 }}
     component: solr
     solr-role: shard
-    shard-name: "{{ $shard.name }}"
+    shard-name: "{{ .name }}"
 spec:
   accessModes:
     - ReadWriteOnce
-{{- if .Values.solr.shards.persistence.storageClass }}
-  storageClassName: "{{ .Values.solr.shards.persistence.storageClass }}"
+{{- if $.Values.solr.shards.persistence.storageClass }}
+  storageClassName: "{{ $.Values.solr.shards.persistence.storageClass }}"
 {{- end }}
   resources:
     requests:
-      storage: {{ .Values.solr.shards.persistence.size }}
-{{- if .Values.solr.shards.persistence.selector }}
+      storage: {{ $.Values.solr.shards.persistence.size }}
+{{- if $.Values.solr.shards.persistence.selector }}
   selector:
-{{ toYaml .Values.solr.shards.persistence.selector | indent 4 }}
+{{ toYaml $.Values.solr.shards.persistence.selector | indent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/cluster/kubernetes/charts/templates/solr/shards-service.yaml
+++ b/cluster/kubernetes/charts/templates/solr/shards-service.yaml
@@ -1,0 +1,21 @@
+{{- range $shard := .Values.solr.shards.shardList }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-solr-{{ $shard.name }}"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: solr
+    solr-role: shard
+    shard-name: "{{ $shard.name }}"
+spec:
+  ports:
+    - name: solr
+      port: 8983
+  selector:
+    release: {{ .Release.Name }}
+    component: solr
+    solr-role: shard
+    shard-name: "{{ $shard.name }}"
+{{- end }}

--- a/cluster/kubernetes/charts/templates/solr/shards-service.yaml
+++ b/cluster/kubernetes/charts/templates/solr/shards-service.yaml
@@ -1,21 +1,21 @@
-{{- range $shard := .Values.solr.shards.shardList }}
+{{- range .Values.solr.shards.shardList }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ template "fullname" . }}-solr-{{ $shard.name }}"
+  name: "{{ template "fullname" $ }}-solr-{{ .name }}"
   labels:
-{{ include "default-labels" . | indent 4 }}
+{{ include "default-labels" $ | indent 4 }}
     component: solr
     solr-role: shard
-    shard-name: "{{ $shard.name }}"
+    shard-name: "{{ .name }}"
 spec:
   ports:
     - name: solr
       port: 8983
   selector:
-    release: {{ .Release.Name }}
+    release: {{ $.Release.Name }}
     component: solr
     solr-role: shard
-    shard-name: "{{ $shard.name }}"
+    shard-name: "{{ .name }}"
 {{- end }}

--- a/cluster/kubernetes/charts/templates/solr/slave-deployment.yaml
+++ b/cluster/kubernetes/charts/templates/solr/slave-deployment.yaml
@@ -22,17 +22,25 @@ spec:
         component: solr
         solr-role: slave
     spec:
+      # Setting fsGroup for the pod allows some provisioners to chown mounted volumes to the given group
+      #   The solr group is 8983 inside the container
+      securityContext:
+        fsGroup: 8983
       initContainers:
         # Wait for the solr-master to become available before starting
         - name: ensure-solr-master
-          image: "{{ .Values.solr.image.repository }}:{{ .Values.solr.image.tag }}"
-          imagePullPolicy: {{ default "" .Values.solr.image.pullPolicy | quote }}
-          args:
-            - "wait-for-solr.sh"
-            - "--max-attempts"
-            - "120"
-            - "--solr-url"
-            - "http://{{ template "fullname" . }}-solr-master:8983"
+          image: radial/busyboxplus:curl
+          command:
+            # Try every 5 seconds for no longer than 10 mins
+            - sh
+            - -c
+            - |
+              for i in $(seq 120); do
+                sleep 5
+                echo "Attempt $i of 120"
+                if curl -k -m 1 -fsSL http://{{ template "fullname" . }}-solr-master:8983/solr/admin/info/system?wt=json; then exit 0; fi
+              done
+              exit 1
       containers:
         - name: solr-slave
           image: "{{ .Values.solr.image.repository }}:{{ .Values.solr.image.tag }}"

--- a/cluster/kubernetes/charts/templates/solr/slave-deployment.yaml
+++ b/cluster/kubernetes/charts/templates/solr/slave-deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-solr-slave"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: solr
+    solr-role: slave
+spec:
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: solr
+      solr-role: slave
+  replicas: 1
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: solr
+        solr-role: slave
+    spec:
+      initContainers:
+        # Wait for the solr-master to become available before starting
+        - name: ensure-solr-master
+          image: "{{ .Values.solr.image.repository }}:{{ .Values.solr.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.solr.image.pullPolicy | quote }}
+          args:
+            - "wait-for-solr.sh"
+            - "--max-attempts"
+            - "120"
+            - "--solr-url"
+            - "http://{{ template "fullname" . }}-solr-master:8983"
+      containers:
+        - name: solr-slave
+          image: "{{ .Values.solr.image.repository }}:{{ .Values.solr.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.solr.image.pullPolicy | quote }}
+          ports:
+            - name: solr
+              containerPort: 8983
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            httpGet:
+              path: /solr/admin/info/system?wt=json
+              port: 8983
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          env:
+            - name: ESGF_SOLR_MASTER_URL
+              value: "http://{{ template "fullname" . }}-solr-master:8983/solr"
+            # Use a shorter replication interval for the local slave than the default
+            - name: ESGF_SOLR_REPLICATION_INTERVAL
+              value: "00:00:60"
+          resources:
+{{ toYaml .Values.solr.slave.resources | indent 12 }}
+          volumeMounts:
+            - name: solr-home
+              mountPath: /esg/solr-home
+      volumes:
+        - name: solr-home
+{{- if .Values.solr.slave.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: "{{ template "fullname" . }}-solr-slave"
+{{- else }}
+          emptyDir: {}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/solr/slave-pvc.yaml
+++ b/cluster/kubernetes/charts/templates/solr/slave-pvc.yaml
@@ -16,6 +16,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.solr.slave.persistence.size }}
+{{- if .Values.solr.slave.persistence.selector }}
   selector:
 {{ toYaml .Values.solr.slave.persistence.selector | indent 4 }}
+{{- end }}
 {{- end }}

--- a/cluster/kubernetes/charts/templates/solr/slave-pvc.yaml
+++ b/cluster/kubernetes/charts/templates/solr/slave-pvc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.solr.slave.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ template "fullname" . }}-solr-slave"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: solr
+    solr-role: slave
+spec:
+  accessModes:
+    - ReadWriteOnce
+{{- if .Values.solr.slave.persistence.storageClass }}
+  storageClassName: "{{ .Values.solr.slave.persistence.storageClass }}"
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.solr.slave.persistence.size }}
+  selector:
+{{ toYaml .Values.solr.slave.persistence.selector | indent 4 }}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/solr/slave-service.yaml
+++ b/cluster/kubernetes/charts/templates/solr/slave-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-solr-slave"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: solr
+    solr-role: slave
+spec:
+  ports:
+    - name: solr
+      port: 8983
+  selector:
+    release: {{ .Release.Name }}
+    component: solr
+    solr-role: slave

--- a/cluster/kubernetes/charts/templates/tds/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/tds/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+        checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
     spec:
       containers:
         - name: tds

--- a/cluster/kubernetes/charts/templates/tds/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/tds/deployment.yaml
@@ -72,11 +72,11 @@ spec:
                 name: "{{ template "fullname" . }}-environment-common"
           env:
             - name: ESGF_ORP_HOME_ENDPOINT
-              value: "https://{{ .Values.hostname }}/esg-orp/home.htm"
+              value: {{ default (printf "https://%s/esg-orp/home.htm" .Values.hostname) .Values.orp.environment.ESGF_ORP_HOME_ENDPOINT | quote }}
             - name: ESGF_AUTH_HOME_ENDPOINT
-              value: "https://{{ .Values.hostname }}/esgf-auth/home/"
+              value: {{ default (printf "https://%s/esgf-auth/home/" .Values.hostname) .Values.orp.environment.ESGF_AUTH_HOME_ENDPOINT | quote }}
             - name: ESGF_REGISTRATION_RELAY_ENDPOINT
-              value: "https://{{ .Values.hostname }}/esg-orp/registration-request.htm"
+              value: {{ default (printf "https://%s/esg-orp/registration-request.htm" .Values.hostname) .Values.orp.environment.ESGF_REGISTRATION_RELAY_ENDPOINT | quote }}
             - name: ESGF_COOKIE_SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/cluster/kubernetes/charts/templates/tds/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/tds/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
         checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
+        checksum/esg-config-overrides: {{ include (print $.Template.BasePath "/configuration/esg-config-overrides.yaml") . | sha256sum }}
     spec:
       containers:
         - name: tds
@@ -74,6 +75,10 @@ spec:
             - mountPath: /esg/certificates/esg-trust-bundle.pem
               name: trust-bundle
               subPath: esg-trust-bundle.pem
+              readOnly: true
+            - mountPath: /esg/config/.overrides
+              name: esg-config-overrides
+              readOnly: true
           resources:
 {{ toYaml .Values.tds.resources | indent 12 }}
       volumes:
@@ -86,3 +91,6 @@ spec:
         - name: trust-bundle
           configMap:
             name: "{{ template "fullname" . }}-trust-bundle"
+        - name: esg-config-overrides
+          configMap:
+            name: "{{ template "fullname" . }}-esg-config-overrides"

--- a/cluster/kubernetes/charts/templates/tds/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/tds/deployment.yaml
@@ -23,6 +23,7 @@ spec:
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
         checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
         checksum/esg-config-overrides: {{ include (print $.Template.BasePath "/configuration/esg-config-overrides.yaml") . | sha256sum }}
+        checksum/thredds-overrides: {{ include (print $.Template.BasePath "/configuration/thredds-overrides.yaml") . | sha256sum }}
     spec:
       containers:
         - name: tds
@@ -79,6 +80,9 @@ spec:
             - mountPath: /esg/config/.overrides
               name: esg-config-overrides
               readOnly: true
+            - mountPath: /esg/content/thredds/.overrides
+              name: thredds-overrides
+              readOnly: true
           resources:
 {{ toYaml .Values.tds.resources | indent 12 }}
       volumes:
@@ -94,3 +98,6 @@ spec:
         - name: esg-config-overrides
           configMap:
             name: "{{ template "fullname" . }}-esg-config-overrides"
+        - name: thredds-overrides
+          configMap:
+            name: "{{ template "fullname" . }}-thredds-overrides"

--- a/cluster/kubernetes/charts/templates/tds/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/tds/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "fullname" . }}-tds"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: tds
+spec:
+  replicas: {{ .Values.tds.replicas }}
+  # Select pods on release and component only, rather than all labels
+  # This means that the selector will match all pods from all versions of the chart when upgrading
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      component: tds
+  template:
+    metadata:
+      labels:
+{{ include "default-labels" . | indent 8 }}
+        component: tds
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
+        checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: tds
+          image: "{{ .Values.tds.image.repository }}:{{ .Values.tds.image.tag }}"
+          imagePullPolicy: {{ default "" .Values.tds.image.pullPolicy | quote }}
+          ports:
+            - name: http
+              containerPort: 8080
+          # The readiness and liveness probes run the same thing, but the liveness
+          # probe just waits a while before kicking in whereas the readiness probe
+          # starts straight away
+          readinessProbe: &probe
+            httpGet:
+              path: /thredds
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            <<: *probe
+            initialDelaySeconds: 600
+          envFrom:
+            - configMapRef:
+                name: "{{ template "fullname" . }}-environment-common"
+          env:
+            - name: ESGF_ORP_HOME_ENDPOINT
+              value: "https://{{ .Values.hostname }}/esg-orp/home.htm"
+            - name: ESGF_AUTH_HOME_ENDPOINT
+              value: "https://{{ .Values.hostname }}/esgf-auth/home/"
+            - name: ESGF_REGISTRATION_RELAY_ENDPOINT
+              value: "https://{{ .Values.hostname }}/esg-orp/registration-request.htm"
+            - name: ESGF_COOKIE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "shared-cookie-secret-key"
+            - name: ESGF_TDS_ADMIN_USERNAME
+              value: rootAdmin
+            - name: ESGF_TDS_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "fullname" . }}-secrets"
+                  key: "rootadmin-password"
+          volumeMounts:
+            - mountPath: /esg/content/thredds/esgcet
+              name: tds-content
+            - mountPath: /esg/data
+              name: tds-data
+              readOnly: true
+            - mountPath: /esg/certificates/esg-trust-bundle.pem
+              name: trust-bundle
+              subPath: esg-trust-bundle.pem
+          resources:
+{{ toYaml .Values.tds.resources | indent 12 }}
+      volumes:
+        - name: tds-content
+          persistentVolumeClaim:
+            claimName: "{{ template "fullname" . }}-tds-content"
+        - name: tds-data
+          persistentVolumeClaim:
+            claimName: "{{ template "fullname" . }}-tds-data"
+        - name: trust-bundle
+          configMap:
+            name: "{{ template "fullname" . }}-trust-bundle"

--- a/cluster/kubernetes/charts/templates/tds/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/tds/deployment.yaml
@@ -66,6 +66,7 @@ spec:
           volumeMounts:
             - mountPath: /esg/content/thredds/esgcet
               name: tds-content
+              readOnly: true
             - mountPath: /esg/data
               name: tds-data
               readOnly: true

--- a/cluster/kubernetes/charts/templates/tds/deployment.yaml
+++ b/cluster/kubernetes/charts/templates/tds/deployment.yaml
@@ -22,9 +22,32 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath "/configuration/secrets.yaml") . | sha256sum }}
         checksum/trust-bundle: {{ include (print $.Template.BasePath "/configuration/trust-bundle.yaml") . | sha256sum }}
         checksum/environment-common: {{ include (print $.Template.BasePath "/configuration/environment-common.yaml") . | sha256sum }}
-        checksum/esg-config-overrides: {{ include (print $.Template.BasePath "/configuration/esg-config-overrides.yaml") . | sha256sum }}
-        checksum/thredds-overrides: {{ include (print $.Template.BasePath "/configuration/thredds-overrides.yaml") . | sha256sum }}
+        checksum/config-overrides: {{ include (print $.Template.BasePath "/configuration/config-overrides.yaml") . | sha256sum }}
     spec:
+      initContainers:
+        # Unpack the required config overrides from the base64-encoded tarballs in the configmap
+        # This process is required because configmaps cannot contain nested directory structures
+        - name: unpack-config-overrides
+          image: busybox
+          command:
+            - "sh"
+            - "-c"
+            - |
+              set -eo pipefail
+              if [ -f /esg/tarballs/esg-config-overrides.tar.gz.b64 ]; then
+                  base64 -d /esg/tarballs/esg-config-overrides.tar.gz.b64 | tar -xz -C /esg/config
+              fi
+              if [ -f /esg/tarballs/thredds-overrides.tar.gz.b64 ]; then
+                  base64 -d /esg/tarballs/thredds-overrides.tar.gz.b64 | tar -xz -C /esg/thredds
+              fi
+          volumeMounts:
+            - mountPath: /esg/config
+              name: esg-config-overrides
+            - mountPath: /esg/thredds
+              name: thredds-overrides
+            - mountPath: /esg/tarballs
+              name: override-tarballs
+              readOnly: true
       containers:
         - name: tds
           image: "{{ .Values.tds.image.repository }}:{{ .Values.tds.image.tag }}"
@@ -96,8 +119,9 @@ spec:
           configMap:
             name: "{{ template "fullname" . }}-trust-bundle"
         - name: esg-config-overrides
-          configMap:
-            name: "{{ template "fullname" . }}-esg-config-overrides"
+          emptyDir: {}
         - name: thredds-overrides
+          emptyDir: {}
+        - name: override-tarballs
           configMap:
-            name: "{{ template "fullname" . }}-thredds-overrides"
+            name: "{{ template "fullname" . }}-config-overrides"

--- a/cluster/kubernetes/charts/templates/tds/pvc-content.yaml
+++ b/cluster/kubernetes/charts/templates/tds/pvc-content.yaml
@@ -14,5 +14,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.tds.content.size }}
+{{- if .Values.tds.content.selector }}
   selector:
 {{ toYaml .Values.tds.content.selector | indent 4 }}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/tds/pvc-content.yaml
+++ b/cluster/kubernetes/charts/templates/tds/pvc-content.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ template "fullname" . }}-tds-content"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: tds
+spec:
+  accessModes:
+    - ReadWriteMany
+{{- if .Values.tds.content.storageClass }}
+  storageClassName: "{{ .Values.tds.content.storageClass }}"
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.tds.content.size }}
+  selector:
+{{ toYaml .Values.tds.content.selector | indent 4 }}

--- a/cluster/kubernetes/charts/templates/tds/pvc-data.yaml
+++ b/cluster/kubernetes/charts/templates/tds/pvc-data.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ template "fullname" . }}-tds-data"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: tds
+spec:
+  accessModes:
+    - ReadWriteMany
+{{- if .Values.tds.data.storageClass }}
+  storageClassName: "{{ .Values.tds.data.storageClass }}"
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.tds.data.size }}
+  selector:
+{{ toYaml .Values.tds.data.selector | indent 4 }}

--- a/cluster/kubernetes/charts/templates/tds/pvc-data.yaml
+++ b/cluster/kubernetes/charts/templates/tds/pvc-data.yaml
@@ -14,5 +14,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.tds.data.size }}
+{{- if .Values.tds.data.selector }}
   selector:
 {{ toYaml .Values.tds.data.selector | indent 4 }}
+{{- end }}

--- a/cluster/kubernetes/charts/templates/tds/service.yaml
+++ b/cluster/kubernetes/charts/templates/tds/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}-tds"
+  labels:
+{{ include "default-labels" . | indent 4 }}
+    component: tds
+spec:
+  ports:
+    - name: http
+      port: 8080
+  selector:
+    release: {{ .Release.Name }}
+    component: tds

--- a/cluster/kubernetes/charts/values.yaml
+++ b/cluster/kubernetes/charts/values.yaml
@@ -1,3 +1,5 @@
+esgConfigOverrides: {}
+
 solr:
   image:
     repository: esgfhub/solr

--- a/cluster/kubernetes/charts/values.yaml
+++ b/cluster/kubernetes/charts/values.yaml
@@ -1,5 +1,3 @@
-esgConfigOverrides: {}
-
 solr:
   image:
     repository: esgfhub/solr

--- a/cluster/kubernetes/charts/values.yaml
+++ b/cluster/kubernetes/charts/values.yaml
@@ -1,3 +1,7 @@
+# These will be overridden by the helm-values command of esgf-setup based on the contents
+# of directories under $ESGF_CONFIG
+configuration: {}
+
 solr:
   image:
     repository: esgfhub/solr

--- a/cluster/kubernetes/charts/values.yaml
+++ b/cluster/kubernetes/charts/values.yaml
@@ -1,0 +1,195 @@
+solr:
+  image:
+#    repository: esgfhub/solr
+    repository: cedadev/esgf-solr
+    tag: latest
+    # pullPolicy:  "IfNotPresent"
+  master:
+    # The resources available to the Solr master
+    resources: {}
+    persistence:
+      # Set this to true to use a PVC with the following properties
+      enabled: false
+      # storageClass: ""
+      size: 10Gi
+      selector: {}
+  slave:
+    # The resources available to the Solr slave
+    resources: {}
+    persistence:
+      # Set this to true to use a PVC with the following properties
+      enabled: false
+      # storageClass: ""
+      size: 10Gi
+      selector: {}
+  shards:
+    # The resources available to each Solr shard
+    resources: {}
+    persistence:
+      # Set this to true to use a PVC with the following properties
+      enabled: false
+      # storageClass: ""
+      size: 10Gi
+      selector: {}
+    shardList: []
+
+postgresEsgcet:
+  image: &postgresImage
+    # repository: esgfhub/postgres
+    repository: cedadev/esgf-postgres
+    tag: latest
+    # pullPolicy:  "IfNotPresent"
+  # The resources available to the postgres-esgcet container
+  resources: {}
+  persistence:
+    # Set this to true to use a PVC with the following properties
+    enabled: false
+    # storageClass: ""
+    size: 10Gi
+    selector: {}
+
+postgresSecurity:
+  image:
+    <<: *postgresImage
+    repository: cedadev/esgf-postgres-security
+  # The resources available to the postgres-security container
+  resources: {}
+  persistence:
+    # Set this to true to use a PVC with the following properties
+    enabled: false
+    # storageClass: ""
+    size: 10Gi
+    selector: {}
+
+orp:
+  image:
+#    repository: esgfhub/orp
+    repository: cedadev/esgf-orp
+    tag: latest
+    # pullPolicy:  "IfNotPresent"
+  replicas: 1
+  # The resources available to each ORP container
+  resources: {}
+
+indexNode:
+  image:
+#    repository: esgfhub/index-node
+    repository: cedadev/esgf-index-node
+    tag: latest
+    # pullPolicy:  "IfNotPresent"
+  replicas: 1
+  # The resources available to each index node container
+  resources: {}
+
+idpNode:
+  image:
+#    repository: esgfhub/idp-node
+    repository: cedadev/esgf-idp-node
+    tag: latest
+    # pullPolicy:  "IfNotPresent"
+  replicas: 1
+  # The resources available to each IDP container
+  resources: {}
+
+tds:
+  image:
+#    repository: esgfhub/tds
+    repository: cedadev/esgf-tds
+    tag: latest
+    # pullPolicy:  "IfNotPresent"
+  replicas: 1
+  # The resources available to each TDS container
+  resources: {}
+  # Information for the data PVC
+  data:
+    # storageClass: ""
+    size: 10Gi
+    selector: {}
+  # Information for the catalog PVC
+  content:
+    # storageClass: ""
+    size: 10Gi
+    selector: {}
+
+cog:
+  image:
+#    repository: esgfhub/cog
+    repository: cedadev/esgf-cog
+    tag: latest
+    # pullPolicy:  "IfNotPresent"
+  replicas: 1
+  # The resources available to each cog container
+  resources: {}
+  # The postgres used by CoG
+  postgres:
+    image: *postgresImage
+    resources: {}
+    persistence:
+      # Set this to true to use a PVC with the following properties
+      enabled: false
+      # storageClass: ""
+      size: 10Gi
+      selector: {}
+
+auth:
+  image:
+#    repository: esgfhub/auth
+    repository: cedadev/esgf-auth
+    tag: latest
+    # pullPolicy:  "IfNotPresent"
+  replicas: 1
+  # The resources available to each auth container
+  resources: {}
+  # The postgres for use by esgf-auth
+  postgres:
+    image: *postgresImage
+    resources: {}
+    persistence:
+      # Set this to true to use a PVC with the following properties
+      enabled: false
+      # storageClass: ""
+      size: 10Gi
+      selector: {}
+
+slcs:
+  image:
+#    repository: esgfhub/slcs
+    repository: cedadev/esgf-slcs
+    tag: latest
+    # pullPolicy:  "IfNotPresent"
+  replicas: 1
+  # The resources available to each SLCS container
+  resources: {}
+  # The postgres for use by the SLCS
+  postgres:
+    image: *postgresImage
+    resources: {}
+    persistence:
+      # Set this to true to use a PVC with the following properties
+      enabled: false
+      # storageClass: ""
+      size: 10Gi
+      selector: {}
+
+proxy:
+  image:
+#    repository: esgfhub/proxy
+    repository: cedadev/esgf-proxy
+    tag: latest
+    # pullPolicy:  "IfNotPresent"
+  replicas: 1
+  # Use this to set the resources available to each index node container
+  resources: {}
+  ingress:
+    # Set this to false to disable ingress rules
+    enabled: true
+    # The ingress mode - one of "kubernetes" (Ingress resource) or "openshift" (Route resource)
+    mode: kubernetes
+
+publisher:
+  image:
+#    repository: esgfhub/publisher
+    repository: cedadev/esgf-publisher
+    tag: latest
+    # pullPolicy:  "IfNotPresent"
+  resources: {}

--- a/cluster/kubernetes/charts/values.yaml
+++ b/cluster/kubernetes/charts/values.yaml
@@ -1,6 +1,8 @@
 # These will be overridden by the helm-values command of esgf-setup based on the contents
 # of directories under $ESGF_CONFIG
-configuration: {}
+configuration:
+  environment: {}
+  overrides: {}
 
 solr:
   image:
@@ -70,6 +72,8 @@ orp:
     tag: latest
     # pullPolicy:  "IfNotPresent"
   replicas: 1
+  # Environment variable overrides for the ORP
+  environment: {}
   # The resources available to each ORP container
   resources: {}
 
@@ -97,6 +101,8 @@ tds:
     tag: latest
     # pullPolicy:  "IfNotPresent"
   replicas: 1
+  # Environment variable overrides for the TDS
+  environment: {}
   # The resources available to each TDS container
   resources: {}
   # Information for the data PVC
@@ -116,6 +122,8 @@ cog:
     tag: latest
     # pullPolicy:  "IfNotPresent"
   replicas: 1
+  # Environment variables for cog
+  environment: {}
   # The resources available to each cog container
   resources: {}
   # The postgres used by CoG
@@ -160,6 +168,8 @@ slcs:
     tag: latest
     # pullPolicy:  "IfNotPresent"
   replicas: 1
+  # Environment overrides for the SLCS
+  environment: {}
   # The resources available to each SLCS container
   resources: {}
   # The postgres for use by the SLCS
@@ -195,4 +205,7 @@ publisher:
     repository: esgfhub/publisher
     tag: latest
     # pullPolicy:  "IfNotPresent"
+  # Environment overrides for the publisher
+  environment: {}
+  # Resources available to the publisher
   resources: {}

--- a/cluster/kubernetes/charts/values.yaml
+++ b/cluster/kubernetes/charts/values.yaml
@@ -1,7 +1,6 @@
 solr:
   image:
-#    repository: esgfhub/solr
-    repository: cedadev/esgf-solr
+    repository: esgfhub/solr
     tag: latest
     # pullPolicy:  "IfNotPresent"
   master:
@@ -34,9 +33,8 @@ solr:
     shardList: []
 
 postgresEsgcet:
-  image: &postgresImage
-    # repository: esgfhub/postgres
-    repository: cedadev/esgf-postgres
+  image:
+    repository: esgfhub/postgres
     tag: latest
     # pullPolicy:  "IfNotPresent"
   # The resources available to the postgres-esgcet container
@@ -50,8 +48,9 @@ postgresEsgcet:
 
 postgresSecurity:
   image:
-    <<: *postgresImage
-    repository: cedadev/esgf-postgres-security
+    repository: esgfhub/postgres-security
+    tag: latest
+    # pullPolicy:  "IfNotPresent"
   # The resources available to the postgres-security container
   resources: {}
   persistence:
@@ -63,8 +62,7 @@ postgresSecurity:
 
 orp:
   image:
-#    repository: esgfhub/orp
-    repository: cedadev/esgf-orp
+    repository: esgfhub/orp
     tag: latest
     # pullPolicy:  "IfNotPresent"
   replicas: 1
@@ -73,8 +71,7 @@ orp:
 
 indexNode:
   image:
-#    repository: esgfhub/index-node
-    repository: cedadev/esgf-index-node
+    repository: esgfhub/index-node
     tag: latest
     # pullPolicy:  "IfNotPresent"
   replicas: 1
@@ -83,8 +80,7 @@ indexNode:
 
 idpNode:
   image:
-#    repository: esgfhub/idp-node
-    repository: cedadev/esgf-idp-node
+    repository: esgfhub/idp-node
     tag: latest
     # pullPolicy:  "IfNotPresent"
   replicas: 1
@@ -93,8 +89,7 @@ idpNode:
 
 tds:
   image:
-#    repository: esgfhub/tds
-    repository: cedadev/esgf-tds
+    repository: esgfhub/tds
     tag: latest
     # pullPolicy:  "IfNotPresent"
   replicas: 1
@@ -113,8 +108,7 @@ tds:
 
 cog:
   image:
-#    repository: esgfhub/cog
-    repository: cedadev/esgf-cog
+    repository: esgfhub/cog
     tag: latest
     # pullPolicy:  "IfNotPresent"
   replicas: 1
@@ -122,7 +116,10 @@ cog:
   resources: {}
   # The postgres used by CoG
   postgres:
-    image: *postgresImage
+    image:
+      repository: esgfhub/postgres
+      tag: latest
+      # pullPolicy:  "IfNotPresent"
     resources: {}
     persistence:
       # Set this to true to use a PVC with the following properties
@@ -133,8 +130,7 @@ cog:
 
 auth:
   image:
-#    repository: esgfhub/auth
-    repository: cedadev/esgf-auth
+    repository: esgfhub/auth
     tag: latest
     # pullPolicy:  "IfNotPresent"
   replicas: 1
@@ -142,7 +138,10 @@ auth:
   resources: {}
   # The postgres for use by esgf-auth
   postgres:
-    image: *postgresImage
+    image:
+      repository: esgfhub/postgres
+      tag: latest
+      # pullPolicy:  "IfNotPresent"
     resources: {}
     persistence:
       # Set this to true to use a PVC with the following properties
@@ -153,8 +152,7 @@ auth:
 
 slcs:
   image:
-#    repository: esgfhub/slcs
-    repository: cedadev/esgf-slcs
+    repository: esgfhub/slcs
     tag: latest
     # pullPolicy:  "IfNotPresent"
   replicas: 1
@@ -162,7 +160,10 @@ slcs:
   resources: {}
   # The postgres for use by the SLCS
   postgres:
-    image: *postgresImage
+    image:
+      repository: esgfhub/postgres
+      tag: latest
+      # pullPolicy:  "IfNotPresent"
     resources: {}
     persistence:
       # Set this to true to use a PVC with the following properties
@@ -173,8 +174,7 @@ slcs:
 
 proxy:
   image:
-#    repository: esgfhub/proxy
-    repository: cedadev/esgf-proxy
+    repository: esgfhub/proxy
     tag: latest
     # pullPolicy:  "IfNotPresent"
   replicas: 1
@@ -188,8 +188,7 @@ proxy:
 
 publisher:
   image:
-#    repository: esgfhub/publisher
-    repository: cedadev/esgf-publisher
+    repository: esgfhub/publisher
     tag: latest
     # pullPolicy:  "IfNotPresent"
   resources: {}

--- a/cluster/kubernetes/gke/filestore-storageclass.yaml
+++ b/cluster/kubernetes/gke/filestore-storageclass.yaml
@@ -1,0 +1,16 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: standard-rwx
+provisioner: com.google.csi.filestore
+parameters:
+  # The tier to use for filestore volumes: standard or premium
+  tier: standard
+  # The location to provision filestore volumes in
+  #   If not given, the location that the CSI driver is running in is used
+  #   See https://cloud.google.com/filestore/docs/regions for available locations
+  location: europe-west3-a
+  # CIDR range to allocate filestore IPs from
+  # reserved-ipv4-cidr: 192.168.92.22/26
+  # Name of the VPC to use (may require custom firewall rules)
+  # network: default

--- a/cluster/kubernetes/gke/helm-overrides.yaml
+++ b/cluster/kubernetes/gke/helm-overrides.yaml
@@ -1,0 +1,48 @@
+# For GKE, enable persistence by default and set sensible storage classes
+solr:
+  master:
+    persistence:
+      enabled: true
+      storageClass: standard
+  slave:
+    persistence:
+      enabled: true
+      storageClass: standard
+  shards:
+    persistence:
+      enabled: true
+      storageClass: standard
+
+postgresEsgcet:
+  persistence:
+    enabled: true
+    storageClass: standard
+
+postgresSecurity:
+  persistence:
+    enabled: true
+    storageClass: standard
+
+tds:
+  data:
+    storageClass: standard-rwx
+  content:
+    storageClass: standard-rwx
+
+cog:
+  postgres:
+    persistence:
+      enabled: true
+      storageClass: standard
+
+auth:
+  postgres:
+    persistence:
+      enabled: true
+      storageClass: standard
+
+slcs:
+  postgres:
+    persistence:
+      enabled: true
+      storageClass: standard

--- a/cluster/kubernetes/gke/s3-csi-storageclass.yaml
+++ b/cluster/kubernetes/gke/s3-csi-storageclass.yaml
@@ -1,0 +1,10 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: standard-rwx
+provisioner: ch.ctrox.csi.s3-driver
+parameters:
+  # Specify which mounter to use
+  #   Can be set to s3backer, s3ql, s3fs or goofys
+  #   See docs for differences
+  mounter: s3fs

--- a/configure/Dockerfile
+++ b/configure/Dockerfile
@@ -1,25 +1,25 @@
 #####
-## This Dockerfile builds an image containing common configuration templates,
-## and scripts that can then be copied into other container images
+## This Dockerfile builds an image containing common configuration templates,
+## and scripts that can then be copied into other container images
 #####
 
-# Use the lightest base image we can
+# Use the lightest base image we can
 FROM alpine
 
-# Install gomplate (for templating) into the bin directory
-ARG GOMPLATE_VERSION=v2.7.0
+# Install gomplate (for templating) into the bin directory
+ARG GOMPLATE_VERSION=2.8.0
 RUN apk --no-cache add curl && \
     mkdir -p /esg/bin && \
     curl -o /esg/bin/gomplate -fsSL https://github.com/hairyhenderson/gomplate/releases/download/${GOMPLATE_VERSION}/gomplate_linux-amd64-slim && \
     chmod 755 /esg/bin/gomplate
-# Copy the scripts into the bin directory
+# Copy the scripts into the bin directory
 COPY ./scripts  /esg/bin
-# Create the default contents of /esg/config with the correct permissions
+# Create the default contents of /esg/config with the correct permissions
 # Non-root users in the root group need to be able to write config files in downstream containers
-# All the Java applications expect the password files to be present, even if they don't need the contents
+# All the Java applications expect the password files to be present, even if they don't need the contents
 RUN mkdir -p /esg/config && \
     echo "changeit" > /esg/config/.esgf_pass && \
     echo "changeit" > /esg/config/.esg_pg_pass && \
     chmod -R g+w /esg/config
-# Copy the config templates as the defaults for /esg/config
+# Copy the config templates as the defaults for /esg/config
 COPY ./config  /esg/config/.defaults

--- a/configure/scripts/build-config.sh
+++ b/configure/scripts/build-config.sh
@@ -5,26 +5,23 @@ set -eo pipefail
 . "$(dirname $BASH_SOURCE)/functions.sh"
 
 #####
-## This script takes a single config directory as it's argument
+## This script takes a single config directory as it's argument
 ##
-## Inside that directory, it looks for special folders named ".defaults" and ".overrides"
+## Inside that directory, it looks for special folders named ".defaults" and ".overrides"
 ##
-## The config directory is then populated by first templating each file in ".defaults",
-## then templating each file in ".overrides", using gomplate
+## The config directory is then populated by first templating each file in ".defaults",
+## then templating each file in ".overrides", using gomplate
 #####
 
 # First, check that we got an argument
 [ -z "$1" ] && error "No config directory given"
 
-# Pass the argument through realpath to canonicalise it
+# Pass the argument through realpath to canonicalise it
 config_dir="$(realpath "$1")"
 
 info "Building configuration in $config_dir"
 
-info "Using environment:"
-env | grep -v "_PASSWORD$"
-
-# First, process the .defaults directory in the root, then the same with .overrides
+# First, process the .defaults directory in the root, then the same with .overrides
 sources=(".defaults"  ".overrides")
 for source in "${sources[@]}"; do
     source_dir="$config_dir/$source"

--- a/configure/scripts/build-config.sh
+++ b/configure/scripts/build-config.sh
@@ -21,14 +21,41 @@ config_dir="$(realpath "$1")"
 
 info "Building configuration in $config_dir"
 
-# First, process the .defaults directory in the root, then the same with .overrides
-sources=(".defaults"  ".overrides")
-for source in "${sources[@]}"; do
-    source_dir="$config_dir/$source"
-    if [ -d "$source_dir" ]; then
-        info "Processing templates from $source_dir"
-        /esg/bin/gomplate --input-dir="$source_dir" --output-dir="$config_dir"
+# We want to maintain the directory structure, and only process files from .defaults
+# if they are not overridden
+defaults_dir="${config_dir}/.defaults"
+overrides_dir="${config_dir}/.overrides"
+
+# Although gomplate has --input-dir and --output-dir options, they do not seem to
+# handle nested directories, which we want
+# We also want to skip files that already exist when handling defaults
+
+# First, process the files in overrides
+if [ -d "$overrides_dir" ]; then
+    info "  Processing files from $overrides_dir"
+    for override_file in $(find "$overrides_dir" -type f); do
+        config_file="${config_dir}/$(realpath --relative-to="$overrides_dir" $override_file)"
+        # Make sure the containing directory exists
+        mkdir -p "$(dirname "$config_file")"
+        # Then template the file using gomplate
+        /esg/bin/gomplate -f "$override_file" -o "$config_file"
+    done
+else
+    warn "  $overrides_dir does not exist - skipping"
+fi
+
+# Then process the files in defaults, skipping any files that exist in the overrides directory
+info "  Processing files from $defaults_dir"
+for default_file in $(find "$defaults_dir" -type f); do
+    relative_path="$(realpath --relative-to="$defaults_dir" $default_file)"
+    config_file="${config_dir}/${relative_path}"
+    override_file="${overrides_dir}/${relative_path}"
+    if [ -f "$override_file" ]; then
+        warn "    $config_file is overridden - skipping"
     else
-        warn "$source_dir does not exist - skipping"
+        # Make sure the containing directory exists
+        mkdir -p "$(dirname "$config_file")"
+        # Then template the file using gomplate
+        /esg/bin/gomplate -f "$default_file" -o "$config_file"
     fi
 done

--- a/docs/_docs/compose/configuration.md
+++ b/docs/_docs/compose/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-category: Usage
+category: Docker Compose
 order: 1.2
 ---
 

--- a/docs/_docs/compose/docker-tips.md
+++ b/docs/_docs/compose/docker-tips.md
@@ -1,6 +1,6 @@
 ---
 title: Docker Tips
-category: Usage
+category: Docker Compose
 order: 1.5
 ---
 

--- a/docs/_docs/compose/publishing.md
+++ b/docs/_docs/compose/publishing.md
@@ -1,6 +1,6 @@
 ---
 title: Publication
-category: Usage
+category: Docker Compose
 order: 1.4
 ---
 

--- a/docs/_docs/compose/quick-start.md
+++ b/docs/_docs/compose/quick-start.md
@@ -1,6 +1,6 @@
 ---
 title: Quick Start
-category: Usage
+category: Docker Compose
 order: 1.1
 ---
 

--- a/docs/_docs/compose/testing.md
+++ b/docs/_docs/compose/testing.md
@@ -1,6 +1,6 @@
 ---
 title: Testing
-category: Usage
+category: Docker Compose
 order: 1.3
 ---
 

--- a/docs/_docs/developer/architecture.md
+++ b/docs/_docs/developer/architecture.md
@@ -1,7 +1,7 @@
 ---
 title: Container Architecture
 category: Developers
-order: 2.1
+order: 3.1
 toc: false
 ---
 

--- a/docs/_docs/developer/comparison.md
+++ b/docs/_docs/developer/comparison.md
@@ -1,7 +1,7 @@
 ---
 title: Comparison to original implementation
 category: Developers
-order: 2.2
+order: 3.2
 ---
 
 This project represents a significant reworking of the original implementation

--- a/docs/_docs/developer/contributing.md
+++ b/docs/_docs/developer/contributing.md
@@ -1,7 +1,7 @@
 ---
 title: Contributing
 category: Developers
-order: 2.3
+order: 3.3
 toc: false
 ---
 

--- a/docs/_docs/kubernetes/google.md
+++ b/docs/_docs/kubernetes/google.md
@@ -1,0 +1,236 @@
+---
+title: Google Kubernetes Engine
+category: Kubernetes
+order: 2.1
+---
+
+This page describe the process for deploying ESGF on
+[Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/).
+
+## Prerequisites
+
+First, ensure that you have installed and configured the
+[Google Cloud SDK](https://cloud.google.com/sdk/) and [Helm](https://helm.sh/) on
+the machine you are deploying from.
+
+The [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) tool is also required,
+and can be installed using `gcloud`:
+
+```bash
+gcloud components install kubectl
+```
+
+If you have not already done so, check out the ESGF Docker repository and ensure that it is
+your current working directory:
+
+```bash
+git clone https://github.com/ESGF/esgf-docker.git
+cd esgf-docker
+```
+
+## Creating a cluster
+
+Use the following command to create a Kubernetes cluster. See the GKE documentation for
+the full range of options:
+
+```bash
+gcloud container clusters create --cluster-version 1.10 esgf-node
+```
+
+This command will create a GKE Kubernetes cluster and configure `kubectl` to point to it.
+
+Next, install Tiller:
+
+```bash
+# Create service account for Tiller
+kubectl -n kube-system create serviceaccount tiller
+# Grant cluster-admin role to service account
+kubectl create clusterrolebinding tiller-cluster-admin \
+    --clusterrole=cluster-admin \
+    --serviceaccount=kube-system:tiller
+# Start Tiller
+helm init --service-account tiller --upgrade
+# Wait for Tiller to start
+kubectl -n kube-system wait --for condition=ready pods -l "app=helm,name=tiller" --timeout 300s
+```
+
+### Install Nginx Ingress Controller
+
+Unlike the [Nginx Ingress Controller](https://kubernetes.github.io/ingress-nginx/), the GCP
+[L7 load-balancer](https://cloud.google.com/load-balancing/docs/https/) that handles `Ingress`
+resources by default in GKE cannot be configured to allow the SSL-passthrough required
+for SSL client certificate authentication. Due to an incompatibility in `urllib2`, we also
+need to use `301` rather than `308` for redirects.
+
+Fortunately, GCP also provides an
+[L4 load-balancer](https://cloud.google.com/load-balancing/docs/network/)
+which can be accessed from GKE using `Service`s with `type: LoadBalancer`. However, we still want to be
+able to use `Ingress` resources as with other clusters. To do this, we install the Nginx Ingress
+Controller behind an L4 load-balancer to route traffic to the relevant Kubernetes services.
+
+```bash
+# Update stable Helm channel
+helm repo update stable
+# Install Nginx Ingress Controller
+#   Due to this bug - https://github.com/kubernetes/ingress-nginx/issues/2994 - we need to
+#   use the 0.17.x series instead of 0.18.x
+helm upgrade ingress stable/nginx-ingress \
+  --install \
+  --namespace kube-system \
+  --set "controller.image.tag=0.17.1" \
+  --set "controller.extraArgs.enable-ssl-passthrough=" \
+  --set-string "controller.config.http-redirect-code=301"
+# Wait for Nginx Ingress Controller to start
+kubectl -n kube-system wait --for condition=ready pods -l "release=ingress" --timeout 300s
+```
+
+To get the external IP that was allocated to the Nginx Ingress Controller's `Service`, use the
+following command:
+
+```bash
+kubectl -n kube-system get service ingress-nginx-ingress-controller | tail -n 1 | awk '{ print $4; }'
+```
+
+### Install GCP Filestore CSI driver and storage class
+
+[Google Cloud Filestore](https://cloud.google.com/filestore/) is Google Cloud's Filesystem-as-a-Service
+offering. We will use this to provide the `ReadWriteMany` volumes required for the TDS/publisher.
+
+In order to provision `ReadWriteMany` volumes using a storage class, we install the
+[Google Cloud Filestore CSI driver](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver):
+
+```bash
+# Set some variables for reuse later
+#   Do not change the service account name
+SA_NAME=gcp-filestore-csi-driver-sa
+PROJECT="$(gcloud config get-value project)"
+IAM_NAME="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+KEY_FILE="$HOME/.gke/gcp_filestore_csi_driver_sa.json"
+
+# Create Google Cloud service account
+gcloud iam service-accounts create "$SA_NAME" \
+  --display-name="GCP Filestore CSI driver service account"
+# Add Cloud Filestore editor role to service account
+gcloud projects add-iam-policy-binding "$PROJECT" \
+  --member "serviceAccount:${IAM_NAME}" \
+  --role roles/file.editor
+# Create key for service account
+gcloud iam service-accounts keys create "$KEY_FILE" --iam-account "$IAM_NAME"
+
+# In order to create new cluster roles, we must first grant ourselves the cluster-admin role in Kubernetes
+GCLOUD_USER="$(gcloud config get-value account)"
+kubectl create clusterrolebinding \
+  "$(echo -n "$GCLOUD_USER" | cut -d"@" -f1 | sed 's/\./-/g')-cluster-admin-binding" \
+  --clusterrole=cluster-admin \
+  --user="$GCLOUD_USER"
+
+# Create the required Kubernetes namespace, service accounts and cluster roles
+#   There is a typo in this YAML that we correct on the way through
+curl -fsSL https://raw.githubusercontent.com/kubernetes-sigs/gcp-filestore-csi-driver/master/deploy/kubernetes/manifests/setup_cluster.yaml | \
+  sed 's/reigstrar/registrar/g' | \
+  kubectl apply -f -
+# Upload the service account key as a secret
+kubectl create secret generic "$SA_NAME" \
+  --from-file="$KEY_FILE" \
+  --namespace=gcp-filestore-csi-driver
+
+# Start the CSI driver components
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gcp-filestore-csi-driver/master/deploy/kubernetes/manifests/node.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gcp-filestore-csi-driver/master/deploy/kubernetes/manifests/controller.yaml
+
+# Wait for the comonents to start
+kubectl -n gcp-filestore-csi-driver wait --for condition=ready \
+  pods -l app=gcp-filestore-csi-driver \
+  --timeout 300s
+
+# Install the storage class
+#   The name is important (it is used in the Helm overrides file for GKE), but the parameters
+#   should be tweaked, in particular the location
+kubectl apply -f ./cluster/kubernetes/gke/filestore-storageclass.yaml
+```
+
+
+## Configure and deploy ESGF components
+
+As with [Minikube](../minikube/), configuration is very similar to
+[Docker Compose](../../compose/quick-start/#configure-environment).
+
+First, configure the DNS entry you want to use for your node to point to the external IP of the Nginx
+Controller's Service. For testing, you can use an [xip.io](http://xip.io/) domain:
+
+```bash
+ESGF_HOSTNAME="$(kubectl -n kube-system get service ingress-nginx-ingress-controller | tail -n 1 | awk '{ print $4; }').xip.io"
+```
+
+Then generate the required configuration and run the Helm chart to deploy the ESGF components:
+
+```bash
+# This should be an empty directory
+export ESGF_CONFIG=/path/to/esgf/config
+# Create an environment file containing the hostname
+cat > "$ESGF_CONFIG/environment" <<EOF
+ESGF_HOSTNAME=${ESGF_HOSTNAME}
+EOF
+# Generate configuration
+./bin/esgf-setup generate-secrets
+./bin/esgf-setup generate-test-certificates
+./bin/esgf-setup create-trust-bundle
+# Deploy the ESGF components
+./bin/esgf-setup helm-values gke | \
+    helm upgrade my-node cluster/kubernetes/charts --install -f -
+# Wait for the ESGF components to start
+kubectl wait --for condition=ready pods -l release=my-node --timeout 600s
+```
+
+You can inspect the state of the pods using `kubectl get pods`, or by using the GCP web console.
+
+Once all the containers are running, you should have a functional ESGF node at `https://${ESGF_HOSTNAME}`.
+
+
+## Test publication
+
+A test publication should work [as for Minikube](http://localhost:4000/kubernetes/minikube/#test-publication).
+
+
+## Cleanup
+
+To uninstall the ESGF components, run:
+
+```bash
+helm delete --purge my-node
+```
+
+This should delete all the Kubernetes resources for the ESGF deployment. It will also delete any GCE persistent
+disks associated with the RWO `PersistentVolumeClaim`s used by the various Postgres databases and Solr indexes.
+
+Currently, the GCP Filestore CSI driver does **not** delete the Filestore instances it creates, so they need to
+be deleted manually.
+
+<div class="note note-warning" markdown="1">
+To delete **all** Filestore instances for the current project, you can use this command:
+
+```bash
+gcloud beta filestore instances list --format="value(name)" | \
+  xargs -n 1 gcloud beta filestore instances delete
+```
+</div>
+
+To delete the cluster:
+
+```bash
+gcloud container clusters delete esgf-node
+```
+
+To remove the service account and IAM policy bindings for the GCP Filestore CSI provisioner service account:
+
+```bash
+PROJECT="$(gcloud config get-value project)"
+IAM_NAME="gcp-filestore-csi-driver-sa@${PROJECT}.iam.gserviceaccount.com"
+
+# Remove the IAM policy binding
+gcloud projects remove-iam-policy-binding "$PROJECT" \
+  --member "serviceAccount:${IAM_NAME}" \
+  --role roles/file.editor
+# Remove the service account
+gcloud iam service-accounts delete "$IAM_NAME"
+```

--- a/docs/_docs/kubernetes/minikube.md
+++ b/docs/_docs/kubernetes/minikube.md
@@ -1,0 +1,150 @@
+---
+title: Minikube
+category: Kubernetes
+order: 2.1
+---
+
+[Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) is a tool that runs
+a single-node Kubernetes cluster inside a VM on your development machine for testing the
+Kubernetes deployment.
+
+## Prerequisites
+
+First, install [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/)
+and the [Helm](https://helm.sh/) CLI.
+
+Then start a Minikube cluster with plenty of RAM. For now, we need to downgrade
+the Kubernetes version due to [this bug](https://github.com/kubernetes/kubernetes/issues/61076).
+See `minikube get-k8s-versions` for the available versions:
+
+```sh
+minikube start --kubernetes-version v1.10.0 --memory 8096 --disk-size 100GB
+```
+
+Pods must be able to loop back to themselves via their own service - this is known
+as "hairpin mode", and requires the docker bridge network to be in promiscuous
+mode:
+
+```sh
+minikube ssh -- sudo ip link set docker0 promisc on
+```
+
+Install Tiller:
+
+```bash
+# Create service account for Tiller
+kubectl -n kube-system create serviceaccount tiller
+# Grant cluster-admin role to service account
+kubectl create clusterrolebinding tiller-cluster-admin \
+    --clusterrole=cluster-admin \
+    --serviceaccount=kube-system:tiller
+# Start Tiller
+helm init --service-account tiller --upgrade
+# Wait for Tiller to start
+kubectl -n kube-system wait --for condition=ready pods -l "app=helm,name=tiller" --timeout 300s
+```
+
+Install the Nginx ingress controller using Helm. Unfortunately, we can't use
+`minikube addons enable ingress` because we need an additional flag to enable
+SSL passthrough, which is required to use SSL client certificates. By default,
+the Nginx ingress controller also uses a `308` response to redirect from `http`
+to `https`. While, strictly speaking, `308` is better than `301`, it is a
+(relatively) recent standard that breaks `urllib2`, and hence CoG:
+
+```bash
+# Update stable Helm channel
+helm repo update stable
+# Install Nginx Ingress Controller
+#   Due to this bug - https://github.com/kubernetes/ingress-nginx/issues/2994 - we need to
+#   use the 0.17.x series instead of 0.18.x
+#   For Minikube, we use the host networking
+helm upgrade ingress stable/nginx-ingress \
+  --install \
+  --namespace kube-system \
+  --set "controller.image.tag=0.17.1" \
+  --set "controller.extraArgs.enable-ssl-passthrough=" \
+  --set-string "controller.config.http-redirect-code=301" \
+  --set controller.hostNetwork=true \
+  --set "controller.extraArgs.report-node-internal-ip-address="
+# Wait for Nginx Ingress Controller to start
+kubectl -n kube-system wait --for condition=ready pods -l "release=ingress" --timeout 300s
+```
+
+
+## Configure and deploy ESGF components
+
+Configuration is very similar to [Docker Compose](../../compose/quick-start/#configure-environment):
+
+```sh
+# This should be an empty directory
+export ESGF_CONFIG=/path/to/esgf/config
+# Create an environment file containing the hostname
+cat > "$ESGF_CONFIG/environment" <<EOF
+ESGF_HOSTNAME=$(minikube ip).xip.io
+EOF
+# Generate configuration
+./bin/esgf-setup generate-secrets
+./bin/esgf-setup generate-test-certificates
+./bin/esgf-setup create-trust-bundle
+# Deploy the ESGF components
+./bin/esgf-setup helm-values minikube | \
+  helm upgrade my-node cluster/kubernetes/charts --install -f -
+# Wait for the ESGF components to start
+kubectl wait --for condition=ready pods -l release=my-node --timeout 600s
+```
+
+You can inspect the state of the pods using `kubectl get pods`, or by launching the dashboard
+using `minikube dashboard`.
+
+Once all the containers are running, visit `https://$ESGF_HOSTNAME` to see the CoG interface.
+Try the following as a basic test of functionality:
+
+  *  Log in with the `rootAdmin` account from CoG (OpenID `https://$ESGF_HOSTNAME/esgf-idp/openid/rootAdmin`)
+     using the password from the `my-node-esgf-node-secrets` secret in Kubernetes, or the file
+     `$ESGF_CONFIG/secrets/rootadmin-password`
+  * Log in with the `rootAdmin` account from the ORP (`https://$ESGF_HOSTNAME/esg-orp`)
+  * Check THREDDS is running at `https://$ESGF_HOSTNAME/thredds`
+  * Check Solr is running at `https://$ESGF_HOSTNAME/solr`
+
+
+## Test publication
+
+Publish the test dataset (similar to [Docker Compose](../../compose/publishing/)):
+
+```sh
+# Scale up the publisher deployment
+$ kubectl scale --replicas=1 deployment my-node-esgf-node-publisher
+# Wait for the publisher pod to start and get the pod name
+# The first time you scale up is when the image gets pulled, so this might take
+# a long time
+$ PUBLISHER_POD="$(kubectl get pods -l "release=my-node,component=publisher" -o name | cut -d "/" -f 2)"
+$ kubectl wait --for condition=ready pods "$PUBLISHER_POD" --timeout 300s
+# Start a shell inside the publisher pod
+$ kubectl exec -it "$PUBLISHER_POD" /usr/local/bin/docker-entrypoint.sh bash
+# Download the data
+[publisher] $ mkdir -p /esg/data/test
+[publisher] $ wget -O /esg/data/test/sftlf.nc http://distrib-coffee.ipsl.jussieu.fr/pub/esgf/dist/externals/sftlf.nc
+# Fetch a certificate
+[publisher] $ fetch-certificate
+# Publish the data
+[publisher] $ esgprep mapfile --project test /esg/data/test
+[publisher] $ esgpublish --project test --map mapfiles/test.test.map --service fileservice
+[publisher] $ esgpublish --project test --map mapfiles/test.test.map --service fileservice --noscan --thredds
+[publisher] $ esgpublish --project test --map mapfiles/test.test.map --service fileservice --noscan --publish
+# Exit the publisher pod
+[publisher] $ exit
+# Scale the deployment back down to remove the pod
+$ kubectl scale --replicas=0 deployment my-node-esgf-node-publisher
+```
+
+After allowing time for the data to replicate from the master to the slave, check that search is working at
+`https://$ESGF_HOSTNAME/search/testproject/` and that the data is accessible from THREDDS.
+
+
+## Cleanup
+
+To delete the Minikube cluster, run:
+
+```bash
+minikube delete
+```

--- a/publisher/scripts/docker-entrypoint.sh
+++ b/publisher/scripts/docker-entrypoint.sh
@@ -20,8 +20,8 @@ export SSL_CERT_FILE=/esg/config/esgcet/trust-bundle.pem
 
 # Compose the database URL
 # Using gomplate here allows us to benefit from _FILE fallback
-ESGF_DATABASE_PASSWORD="$(/esg/bin/gomplate -i '{{ getenv "ESGF_DATABASE_PASSWORD" }}')"
-export DATABASE_URL="postgresql://${ESGF_DATABASE_USER}:${ESGF_DATABASE_PASSWORD}@${ESGF_DATABASE_HOST}:${ESGF_DATABASE_PORT}/${ESGF_DATABASE_NAME}"
+DB_PASS="$(/esg/bin/gomplate -i '{{ getenv "ESGF_DATABASE_PASSWORD" }}')"
+export DATABASE_URL="postgresql://${ESGF_DATABASE_USER}:${DB_PASS}@${ESGF_DATABASE_HOST}:${ESGF_DATABASE_PORT}/${ESGF_DATABASE_NAME}"
 
 ###
 # Build the configuration directory

--- a/publisher/scripts/docker-entrypoint.sh
+++ b/publisher/scripts/docker-entrypoint.sh
@@ -11,22 +11,24 @@ set -euo pipefail
 ## values from the environment and running "esginitialize -c"
 #####
 
-# Make sure the trusted certificates have been updated
+# Make sure the trusted certificates have been updated
 info "Updating trusted certificates"
-# Combine the trusted certificates into a single bundle and make sure Python and curl use it
+# Combine the trusted certificates into a single bundle and make sure Python and curl use it
 cat /etc/ssl/certs/ca-certificates.crt > /esg/config/esgcet/trust-bundle.pem
 cat /esg/certificates/esg-trust-bundle.pem >> /esg/config/esgcet/trust-bundle.pem
 export SSL_CERT_FILE=/esg/config/esgcet/trust-bundle.pem
 
-# Compose the database URL
-export DATABASE_URL="postgresql://${ESGF_DATABASE_USER}:$(< "$ESGF_DATABASE_PASSWORD_FILE")@${ESGF_DATABASE_HOST}:${ESGF_DATABASE_PORT}/${ESGF_DATABASE_NAME}"
+# Compose the database URL
+# Using gomplate here allows us to benefit from _FILE fallback
+ESGF_DATABASE_PASSWORD="$(/esg/bin/gomplate -i '{{ getenv "ESGF_DATABASE_PASSWORD" }}')"
+export DATABASE_URL="postgresql://${ESGF_DATABASE_USER}:${ESGF_DATABASE_PASSWORD}@${ESGF_DATABASE_HOST}:${ESGF_DATABASE_PORT}/${ESGF_DATABASE_NAME}"
 
 ###
-# Build the configuration directory
+# Build the configuration directory
 ###
 /esg/bin/build-config.sh /esg/config/esgcet
 
-# Initialise the schema migration
+# Initialise the schema migration
 info "Enabling schema versioning"
 if python -m esgcet.schema_migration.manage db_version "${DATABASE_URL}" 1>/dev/null 2>&1; then
     info "  Schema versioning already enabled - skipping"
@@ -40,5 +42,5 @@ esginitialize -c
 
 info "Intialisation complete"
 
-# Execute the specified command
+# Execute the specified command
 exec "$@"

--- a/setup/Dockerfile
+++ b/setup/Dockerfile
@@ -25,9 +25,9 @@ ARG COMPOSE_VERSION=1.22.0
 RUN curl -fsSL https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-# Install jq and PyYAML
+# Install jq
 RUN apt-get update && \
-    apt-get install -y jq python-yaml && \
+    apt-get install -y jq && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy the gomplate binary from esgf-configure

--- a/setup/Dockerfile
+++ b/setup/Dockerfile
@@ -20,10 +20,15 @@ FROM ${ESGF_HUB}/${ESGF_PREFIX}configure:${ESGF_VERSION} as configuration
 # Base container is the JDK, which has openssl and keytool
 FROM openjdk:8-jdk
 
-# Install docker-compose for config generation
+# Install docker-compose for Compose config generation
 ARG COMPOSE_VERSION=1.22.0
 RUN curl -fsSL https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
+
+# Install jq and PyYAML
+RUN apt-get update && \
+    apt-get install -y jq python-yaml && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy the gomplate binary from esgf-configure
 COPY --from=configuration /esg/bin/gomplate /usr/local/bin/gomplate

--- a/setup/scripts/compose-file
+++ b/setup/scripts/compose-file
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
 #####
-## This script is a wrapper for docker-compose that makes sure the
-## environment for the deployment has been imported and injects
-## Solr shard configuration
+## This script injects Solr shard configuration into the main docker-compose.yml
+## based on a solr_shards.yaml in $ESGF_CONFIG
 #####
 
 set -eu

--- a/setup/scripts/docker-entrypoint.sh
+++ b/setup/scripts/docker-entrypoint.sh
@@ -4,7 +4,11 @@ set -e
 
 # Before running any commands, export the variables defined in /esg/environment
 if [ -f "/esg/environment" ]; then
-    export $(grep -v '#' "/esg/environment")
+    # "set -a" means that every variable that is assigned until "set +a" is
+    # automatically exported
+    set -a
+    source /esg/environment
+    set +a
 fi
 
 exec "$@"

--- a/setup/scripts/functions.sh
+++ b/setup/scripts/functions.sh
@@ -22,10 +22,10 @@ function indent {
 }
 
 function yaml2json {
-    python -c 'import sys, yaml, json; print json.dumps(yaml.load(sys.stdin))'
+    gomplate -i '{{ ds "input" | toJSON }}' -d input=stdin:?type=application/yaml
 }
 function json2yaml {
-    python -c 'import sys, yaml, json; print yaml.safe_dump(json.load(sys.stdin), default_style="|", default_flow_style=False)'
+    gomplate -i '{{ ds "input" | toYAML }}' -d input=stdin:?type=application/json
 }
 function merge_yaml {
     # Convert the source files to JSON

--- a/setup/scripts/functions.sh
+++ b/setup/scripts/functions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #####
-## This file contains some handy functions used by all scripts
+## This file contains some handy functions used by all scripts
 #####
 
 function bold { tput -T screen bold; echo -n "$1"; tput -T screen sgr0; }
@@ -11,12 +11,28 @@ function warn { YELLOW=3; echo "$(bold "$(colored "$YELLOW" "[WARN] $1")")"; }
 function error { RED=1; echo "$(bold "$(colored "$RED" "[ERROR] $1")")" 1>&2; exit 1; }
 
 function indent {
-    # This function applies the specified indent to lines from stdin and writes
-    # back to stdout
+    # This function applies the specified indent to lines from stdin and writes
+    # back to stdout
     while read -r line; do
-        # First echo same spaces, but no newline
+        # First echo same spaces, but no newline
         echo -n "$(head -c $1 < /dev/zero | tr "\0" " ")"
-        # Then echo the line
+        # Then echo the line
         echo "$line"
     done
+}
+
+function yaml2json {
+    python -c 'import sys, yaml, json; print json.dumps(yaml.load(sys.stdin))'
+}
+function json2yaml {
+    python -c 'import sys, yaml, json; print yaml.safe_dump(json.load(sys.stdin), default_style="|", default_flow_style=False)'
+}
+function merge_yaml {
+    # Convert the source files to JSON
+    JSON1="$(mktemp)"
+    JSON2="$(mktemp)"
+    yaml2json < "$1" > "$JSON1"
+    yaml2json < "$2" > "$JSON2"
+    # Merge the JSON sources using jq and convert the result back to YAML
+    jq -s '.[0] * .[1]' "$JSON1" "$JSON2" | json2yaml
 }

--- a/setup/scripts/generate-test-certificates
+++ b/setup/scripts/generate-test-certificates
@@ -6,12 +6,12 @@ set -eo pipefail
 
 
 #####
-## This script generates test certificates for a local test installation. These
-## certificates should obviously not be used in production.
+## This script generates test certificates for a local test installation. These
+## certificates should obviously not be used in production.
 ##
 ## The following certificates are generated, unless they already exist:
 ##
-##   1. A self-signed CA for the SLCS
+##   1. A self-signed CA for the SLCS
 ##   2. A self-signed host certificate for SSL
 #####
 

--- a/setup/scripts/helm-values
+++ b/setup/scripts/helm-values
@@ -104,21 +104,22 @@ function config2base64 {
 }
 overrides_yaml_file="$(mktemp)"
 echo "configuration:" > "$overrides_yaml_file"
+echo "  overrides:" >> "$overrides_yaml_file"
 if [ -d "/esg/auth" ]; then
-    echo "  auth-overrides.tar.gz.b64: |-" >> "$overrides_yaml_file"
-    config2base64 /esg/auth | indent 4 >> "$overrides_yaml_file"
+    echo "    auth-overrides.tar.gz.b64: |-" >> "$overrides_yaml_file"
+    config2base64 /esg/auth | indent 6 >> "$overrides_yaml_file"
 fi
 if [ -d "/esg/config" ]; then
-    echo "  esg-config-overrides.tar.gz.b64: |-" >> "$overrides_yaml_file"
-    config2base64 /esg/config | indent 4 >> "$overrides_yaml_file"
+    echo "    esg-config-overrides.tar.gz.b64: |-" >> "$overrides_yaml_file"
+    config2base64 /esg/config | indent 6 >> "$overrides_yaml_file"
 fi
 if [ -d "/esg/publisher" ]; then
-    echo "  publisher-overrides.tar.gz.b64: |-" >> "$overrides_yaml_file"
-    config2base64 /esg/publisher | indent 4 >> "$overrides_yaml_file"
+    echo "    publisher-overrides.tar.gz.b64: |-" >> "$overrides_yaml_file"
+    config2base64 /esg/publisher | indent 6 >> "$overrides_yaml_file"
 fi
 if [ -d "/esg/thredds" ]; then
-    echo "  thredds-overrides.tar.gz.b64: |-" >> "$overrides_yaml_file"
-    config2base64 /esg/thredds | indent 4 >> "$overrides_yaml_file"
+    echo "    thredds-overrides.tar.gz.b64: |-" >> "$overrides_yaml_file"
+    config2base64 /esg/thredds | indent 6 >> "$overrides_yaml_file"
 fi
 overrides_yaml="$(cat "$overrides_yaml_file")"
 

--- a/setup/scripts/helm-values
+++ b/setup/scripts/helm-values
@@ -4,24 +4,18 @@ set -eo pipefail
 
 . "$(dirname $BASH_SOURCE)/functions.sh"
 
-
 #####
-## This script outputs YAML configuration for use with the esgf-helm Helm chart
+## This script outputs YAML configuration for use with the esgf-helm Helm chart
 #####
 
 CERTS="/esg/certificates"
 SECRETS="/esg/secrets"
 
-info "Writing YAML for use with esgf-helm chart" 1>&2
-
-[ -z "$ESGF_HOSTNAME" ] && error "ESGF_HOSTNAME must be set"
-
-# First write the hostname
+# First write the hostname
 echo "hostname: $ESGF_HOSTNAME"
 echo ""
 
-# Write the certificates YAML file
-info "  Writing certificates" 1>&2
+# Write the certificates YAML file
 echo "certificates:"
 echo "  esg-trust-bundle.pem: |"
 cat "$CERTS/esg-trust-bundle.pem" | indent 4
@@ -35,11 +29,9 @@ echo "  slcsca.key: |"
 cat "$CERTS/slcsca/ca.key" | indent 4
 echo ""
 
-# Write the secrets YAML file
-info "  Writing secrets" 1>&2
+# Write the secrets YAML file
 echo "secrets:"
 for file in $(find "$SECRETS" -type f -maxdepth 1); do
     echo "  ${file#"$SECRETS/"}: $(cat "$file")"
 done
 
-info "Done" 1>&2

--- a/setup/scripts/helm-values
+++ b/setup/scripts/helm-values
@@ -6,112 +6,150 @@ set -eo pipefail
 
 #####
 # This script outputs YAML configuration for use with the ESGF Helm chart
-#
-# This process comes in two parts:
-#   1. Configuration from $ESGF_CONFIG
-#   2. Overrides for the specified cluster type
 #####
 
 CLUSTER_TYPE="$1"
 [ -z "$CLUSTER_TYPE" ] && error "Please specify a cluster type"
 
-#####
-## ESGF_CONFIG as YAML
-#####
-ESGF_CONFIG_VALUES="$(mktemp)"
+## Start with required stuff - hostname, image versions, certificates and secrets
+required_yaml="$(gomplate <<"EOF"
+hostname: {{ .Env.ESGF_HOSTNAME }}
 
-# Hostname and image information
-cat > "$ESGF_CONFIG_VALUES" <<EOF
-hostname: ${ESGF_HOSTNAME}
 solr:
   image:
-    repository: ${ESGF_HUB}/${ESGF_PREFIX}solr
-    tag: ${ESGF_VERSION}
+    repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}solr
+    tag: {{ .Env.ESGF_VERSION }}
 postgresEsgcet:
   image:
-    repository: ${ESGF_HUB}/${ESGF_PREFIX}postgres
-    tag: ${ESGF_VERSION}
+    repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}postgres
+    tag: {{ .Env.ESGF_VERSION }}
 postgresSecurity:
   image:
-    repository: ${ESGF_HUB}/${ESGF_PREFIX}postgres-security
-    tag: ${ESGF_VERSION}
+    repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}postgres-security
+    tag: {{ .Env.ESGF_VERSION }}
 orp:
   image:
-    repository: ${ESGF_HUB}/${ESGF_PREFIX}orp
-    tag: ${ESGF_VERSION}
+    repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}orp
+    tag: {{ .Env.ESGF_VERSION }}
 indexNode:
   image:
-    repository: ${ESGF_HUB}/${ESGF_PREFIX}index-node
-    tag: ${ESGF_VERSION}
+    repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}index-node
+    tag: {{ .Env.ESGF_VERSION }}
 idpNode:
   image:
-    repository: ${ESGF_HUB}/${ESGF_PREFIX}idp-node
-    tag: ${ESGF_VERSION}
+    repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}idp-node
+    tag: {{ .Env.ESGF_VERSION }}
 tds:
   image:
-    repository: ${ESGF_HUB}/${ESGF_PREFIX}tds
-    tag: ${ESGF_VERSION}
+    repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}tds
+    tag: {{ .Env.ESGF_VERSION }}
 cog:
   image:
-    repository: ${ESGF_HUB}/${ESGF_PREFIX}cog
-    tag: ${ESGF_VERSION}
+    repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}cog
+    tag: {{ .Env.ESGF_VERSION }}
   postgres:
     image:
-      repository: ${ESGF_HUB}/${ESGF_PREFIX}postgres
-      tag: ${ESGF_VERSION}
+      repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}postgres
+      tag: {{ .Env.ESGF_VERSION }}
 auth:
   image:
-    repository: ${ESGF_HUB}/${ESGF_PREFIX}auth
-    tag: ${ESGF_VERSION}
+    repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}auth
+    tag: {{ .Env.ESGF_VERSION }}
   postgres:
     image:
-      repository: ${ESGF_HUB}/${ESGF_PREFIX}postgres
-      tag: ${ESGF_VERSION}
+      repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}postgres
+      tag: {{ .Env.ESGF_VERSION }}
 slcs:
   image:
-    repository: ${ESGF_HUB}/${ESGF_PREFIX}slcs
-    tag: ${ESGF_VERSION}
+    repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}slcs
+    tag: {{ .Env.ESGF_VERSION }}
   postgres:
     image:
-      repository: ${ESGF_HUB}/${ESGF_PREFIX}postgres
-      tag: ${ESGF_VERSION}
+      repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}postgres
+      tag: {{ .Env.ESGF_VERSION }}
 proxy:
   image:
-    repository: ${ESGF_HUB}/${ESGF_PREFIX}proxy
-    tag: ${ESGF_VERSION}
+    repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}proxy
+    tag: {{ .Env.ESGF_VERSION }}
 publisher:
   image:
-    repository: ${ESGF_HUB}/${ESGF_PREFIX}publisher
-    tag: ${ESGF_VERSION}
+    repository: {{ .Env.ESGF_HUB }}/{{ .Env.ESGF_PREFIX }}publisher
+    tag: {{ .Env.ESGF_VERSION }}
+
+certificates:
+  esg-trust-bundle.pem: |
+{{ file.Read "/esg/certificates/esg-trust-bundle.pem" | indent 4 }}
+  hostcert.crt: |
+{{ file.Read "/esg/certificates/hostcert/hostcert.crt" | indent 4 }}
+  hostcert.key: |
+{{ file.Read "/esg/certificates/hostcert/hostcert.key" | indent 4 }}
+  slcsca.crt: |
+{{ file.Read "/esg/certificates/slcsca/ca.crt" | indent 4 }}
+  slcsca.key: |
+{{ file.Read "/esg/certificates/slcsca/ca.key" | indent 4 }}
+
+secrets:
+{{- range (file.ReadDir "/esg/secrets") }}
+  {{ . }}: >-
+{{ file.Read (printf "/esg/secrets/%s" .) | indent 4 }}
+{{- end }}
 EOF
+)"
 
-# Certificates
-CERTS="/esg/certificates"
-echo "certificates:" >> "$ESGF_CONFIG_VALUES"
-echo "  esg-trust-bundle.pem: |" >> "$ESGF_CONFIG_VALUES"
-indent 4 < "$CERTS/esg-trust-bundle.pem" >> "$ESGF_CONFIG_VALUES"
-echo "  hostcert.crt: |" >> "$ESGF_CONFIG_VALUES"
-indent 4 < "$CERTS/hostcert/hostcert.crt" >> "$ESGF_CONFIG_VALUES"
-echo "  hostcert.key: |" >> "$ESGF_CONFIG_VALUES"
-indent 4 < "$CERTS/hostcert/hostcert.key" >> "$ESGF_CONFIG_VALUES"
-echo "  slcsca.crt: |" >> "$ESGF_CONFIG_VALUES"
-indent 4 < "$CERTS/slcsca/ca.crt" >> "$ESGF_CONFIG_VALUES"
-echo "  slcsca.key: |" >> "$ESGF_CONFIG_VALUES"
-indent 4 < "$CERTS/slcsca/ca.key" >> "$ESGF_CONFIG_VALUES"
-
-# Finally, write the available secrets
-SECRETS="/esg/secrets"
-echo "secrets:" >> "$ESGF_CONFIG_VALUES"
-for file in $(find "$SECRETS" -type f -maxdepth 1); do
-    echo "  ${file#"$SECRETS/"}: $(cat "$file")" >> "$ESGF_CONFIG_VALUES"
-done
-
-#####
-## Work out if there are cluster type overrides to include
-#####
-CLUSTER_TYPE_OVERRIDES="cluster/kubernetes/${CLUSTER_TYPE}/helm-overrides.yaml"
-if [ -f "$CLUSTER_TYPE_OVERRIDES" ]; then
-    merge_yaml "$ESGF_CONFIG_VALUES" "$CLUSTER_TYPE_OVERRIDES"
-else
-    cat "$ESGF_CONFIG_VALUES"
+# Produce base64-encoded tarballs for any config overrides
+function config2base64 {
+    pushd $1 > /dev/null
+    tar -cz * | base64
+    popd > /dev/null
+}
+overrides_yaml_file="$(mktemp)"
+echo "configuration:" > "$overrides_yaml_file"
+if [ -d "/esg/auth" ]; then
+    echo "  auth-overrides.tar.gz.b64: |-" >> "$overrides_yaml_file"
+    config2base64 /esg/auth | indent 4 >> "$overrides_yaml_file"
 fi
+if [ -d "/esg/config" ]; then
+    echo "  esg-config-overrides.tar.gz.b64: |-" >> "$overrides_yaml_file"
+    config2base64 /esg/config | indent 4 >> "$overrides_yaml_file"
+fi
+if [ -d "/esg/publisher" ]; then
+    echo "  publisher-overrides.tar.gz.b64: |-" >> "$overrides_yaml_file"
+    config2base64 /esg/publisher | indent 4 >> "$overrides_yaml_file"
+fi
+if [ -d "/esg/thredds" ]; then
+    echo "  thredds-overrides.tar.gz.b64: |-" >> "$overrides_yaml_file"
+    config2base64 /esg/thredds | indent 4 >> "$overrides_yaml_file"
+fi
+overrides_yaml="$(cat "$overrides_yaml_file")"
+
+# Include shard config
+if [ -f /esg/solr_shards.yaml ]; then
+    solr_shards_yaml="$(gomplate --datasource shards=/esg/solr_shards.yaml  <<"EOF"
+{{- define "shard-name" }}{{ if has . "name" }}{{ .name }}{{ else }}{{ (urlParse .url).Host | replaceAll "." "-" }}{{ end }}{{ end }}
+solr:
+  shards:
+    shardList:
+{{- range (datasource "shards").shards }}
+      - name: "{{ template "shard-name" . }}"
+        url: "{{ .url }}"
+        {{- if has . "replicationInterval" }}
+        replicationInterval: "{{ .replicationInterval }}"
+        {{- end }}
+{{- end }}
+EOF
+)"
+fi
+
+# Work out if there are cluster type overrides to include
+cluster_type_overrides="cluster/kubernetes/${CLUSTER_TYPE}/helm-overrides.yaml"
+if [ -f "$cluster_type_overrides" ]; then
+    cluster_type_yaml="$(cat "$cluster_type_overrides")"
+fi
+
+# Include any user overrides
+user_overrides="/esg/helm-overrides.yaml"
+if [ -f "$user_overrides" ]; then
+    user_overrides_yaml="$(cat "$user_overrides")"
+fi
+
+merge_yaml "$required_yaml" "$overrides_yaml" "$solr_shards_yaml" "$cluster_type_yaml" "$user_overrides_yaml"

--- a/setup/scripts/helm-values
+++ b/setup/scripts/helm-values
@@ -5,33 +5,113 @@ set -eo pipefail
 . "$(dirname $BASH_SOURCE)/functions.sh"
 
 #####
-## This script outputs YAML configuration for use with the esgf-helm Helm chart
+# This script outputs YAML configuration for use with the ESGF Helm chart
+#
+# This process comes in two parts:
+#   1. Configuration from $ESGF_CONFIG
+#   2. Overrides for the specified cluster type
 #####
 
+CLUSTER_TYPE="$1"
+[ -z "$CLUSTER_TYPE" ] && error "Please specify a cluster type"
+
+#####
+## ESGF_CONFIG as YAML
+#####
+ESGF_CONFIG_VALUES="$(mktemp)"
+
+# Hostname and image information
+cat > "$ESGF_CONFIG_VALUES" <<EOF
+hostname: ${ESGF_HOSTNAME}
+solr:
+  image:
+    repository: ${ESGF_HUB}/${ESGF_PREFIX}solr
+    tag: ${ESGF_VERSION}
+postgresEsgcet:
+  image:
+    repository: ${ESGF_HUB}/${ESGF_PREFIX}postgres
+    tag: ${ESGF_VERSION}
+postgresSecurity:
+  image:
+    repository: ${ESGF_HUB}/${ESGF_PREFIX}postgres-security
+    tag: ${ESGF_VERSION}
+orp:
+  image:
+    repository: ${ESGF_HUB}/${ESGF_PREFIX}orp
+    tag: ${ESGF_VERSION}
+indexNode:
+  image:
+    repository: ${ESGF_HUB}/${ESGF_PREFIX}index-node
+    tag: ${ESGF_VERSION}
+idpNode:
+  image:
+    repository: ${ESGF_HUB}/${ESGF_PREFIX}idp-node
+    tag: ${ESGF_VERSION}
+tds:
+  image:
+    repository: ${ESGF_HUB}/${ESGF_PREFIX}tds
+    tag: ${ESGF_VERSION}
+cog:
+  image:
+    repository: ${ESGF_HUB}/${ESGF_PREFIX}cog
+    tag: ${ESGF_VERSION}
+  postgres:
+    image:
+      repository: ${ESGF_HUB}/${ESGF_PREFIX}postgres
+      tag: ${ESGF_VERSION}
+auth:
+  image:
+    repository: ${ESGF_HUB}/${ESGF_PREFIX}auth
+    tag: ${ESGF_VERSION}
+  postgres:
+    image:
+      repository: ${ESGF_HUB}/${ESGF_PREFIX}postgres
+      tag: ${ESGF_VERSION}
+slcs:
+  image:
+    repository: ${ESGF_HUB}/${ESGF_PREFIX}slcs
+    tag: ${ESGF_VERSION}
+  postgres:
+    image:
+      repository: ${ESGF_HUB}/${ESGF_PREFIX}postgres
+      tag: ${ESGF_VERSION}
+proxy:
+  image:
+    repository: ${ESGF_HUB}/${ESGF_PREFIX}proxy
+    tag: ${ESGF_VERSION}
+publisher:
+  image:
+    repository: ${ESGF_HUB}/${ESGF_PREFIX}publisher
+    tag: ${ESGF_VERSION}
+EOF
+
+# Certificates
 CERTS="/esg/certificates"
+echo "certificates:" >> "$ESGF_CONFIG_VALUES"
+echo "  esg-trust-bundle.pem: |" >> "$ESGF_CONFIG_VALUES"
+indent 4 < "$CERTS/esg-trust-bundle.pem" >> "$ESGF_CONFIG_VALUES"
+echo "  hostcert.crt: |" >> "$ESGF_CONFIG_VALUES"
+indent 4 < "$CERTS/hostcert/hostcert.crt" >> "$ESGF_CONFIG_VALUES"
+echo "  hostcert.key: |" >> "$ESGF_CONFIG_VALUES"
+indent 4 < "$CERTS/hostcert/hostcert.key" >> "$ESGF_CONFIG_VALUES"
+echo "  slcsca.crt: |" >> "$ESGF_CONFIG_VALUES"
+indent 4 < "$CERTS/slcsca/ca.crt" >> "$ESGF_CONFIG_VALUES"
+echo "  slcsca.key: |" >> "$ESGF_CONFIG_VALUES"
+indent 4 < "$CERTS/slcsca/ca.key" >> "$ESGF_CONFIG_VALUES"
+
+# Finally, write the available secrets
 SECRETS="/esg/secrets"
-
-# First write the hostname
-echo "hostname: $ESGF_HOSTNAME"
-echo ""
-
-# Write the certificates YAML file
-echo "certificates:"
-echo "  esg-trust-bundle.pem: |"
-cat "$CERTS/esg-trust-bundle.pem" | indent 4
-echo "  hostcert.crt: |"
-cat "$CERTS/hostcert/hostcert.crt" | indent 4
-echo "  hostcert.key: |"
-cat "$CERTS/hostcert/hostcert.key" | indent 4
-echo "  slcsca.crt: |"
-cat "$CERTS/slcsca/ca.crt" | indent 4
-echo "  slcsca.key: |"
-cat "$CERTS/slcsca/ca.key" | indent 4
-echo ""
-
-# Write the secrets YAML file
-echo "secrets:"
+echo "secrets:" >> "$ESGF_CONFIG_VALUES"
 for file in $(find "$SECRETS" -type f -maxdepth 1); do
-    echo "  ${file#"$SECRETS/"}: $(cat "$file")"
+    echo "  ${file#"$SECRETS/"}: $(cat "$file")" >> "$ESGF_CONFIG_VALUES"
 done
 
+#####
+## Work out if there are cluster type overrides to include
+#####
+CLUSTER_TYPE_OVERRIDES="cluster/kubernetes/${CLUSTER_TYPE}/helm-overrides.yaml"
+if [ -f "$CLUSTER_TYPE_OVERRIDES" ]; then
+    merge_yaml "$ESGF_CONFIG_VALUES" "$CLUSTER_TYPE_OVERRIDES"
+else
+    cat "$ESGF_CONFIG_VALUES"
+fi


### PR DESCRIPTION
Changes for #86.

This ticket moves the Helm charts into a `cluster` directory in the main ESGF Docker repo to prevent them being forgotten about.

Changes are tested using Docker Compose, Minikube and Google Kubernetes Engine.