### PR TITLE
fetch-certificate needs input arguments

### DIFF
--- a/publisher/scripts/fetch-certificate
+++ b/publisher/scripts/fetch-certificate
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
 
 . /esg/bin/functions.sh
 


### PR DESCRIPTION
Fixes #91. `fetch-certificate` can now be called with no arguments.