### PR TITLE
Added access log fifo pipe 

### DIFF
--- a/deploy/kubernetes/chart/templates/thredds/deployment.yaml
+++ b/deploy/kubernetes/chart/templates/thredds/deployment.yaml
@@ -85,6 +85,7 @@ spec:
               mkfifo /thredds/logs/fmrc.log
               mkfifo /thredds/logs/threddsServlet.log
               mkfifo /thredds/logs/cache.log
+              mkfifo /thredds/logs/localhost_access_log.txt
           {{- with .Values.data.securityContext }}
           securityContext: {{ toYaml . | nindent 12 }}
           {{- end }}
@@ -134,7 +135,7 @@ spec:
             {{- include "esgf.data.volumeMounts" . | nindent 12 }}
         # Tail the log pipes
         {{- $topContext := . }}
-        {{- range (list "serverStartup.log" "catalogInit.log" "httpout.log" "featureCollectionScan.log" "fmrc.log" "threddsServlet.log" "cache.log") }}
+        {{- range (list "serverStartup.log" "catalogInit.log" "httpout.log" "featureCollectionScan.log" "fmrc.log" "threddsServlet.log" "cache.log" "localhost_access_log.txt") }}
         - name: thredds-log-{{ trimSuffix ".log" . | lower }}
           {{ include "esgf.deployment.image" (list $topContext $thredds.image) }}
           args:

--- a/images/tomcat/server.xml
+++ b/images/tomcat/server.xml
@@ -172,7 +172,7 @@
              Note: The pattern used is equivalent to using pattern="common" -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log" suffix=".txt"
-               pattern="%h %l %u %t &quot;%r&quot; %s %b"
+               pattern="combined"
                renameOnRotate="true"
                rotateable="false"
         />

--- a/images/tomcat/server.xml
+++ b/images/tomcat/server.xml
@@ -172,7 +172,10 @@
              Note: The pattern used is equivalent to using pattern="common" -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log" suffix=".txt"
-               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+               pattern="%h %l %u %t &quot;%r&quot; %s %b"
+               renameOnRotate="true"
+               rotateable="false"
+        />
 
       </Host>
     </Engine>


### PR DESCRIPTION
Modified valve not to rotate output. `renameOnRotate` setting means that the timestamp will not be included until rotated. These settings combined should mean that the pipe is never interrupted.
https://tomcat.apache.org/tomcat-7.0-doc/api/org/apache/catalina/valves/AccessLogValve.html#renameOnRotate 