### PR TITLE
Updated pip version in ansible docker role

### DIFF
--- a/deploy/ansible/roles/docker/tasks/main.yml
+++ b/deploy/ansible/roles/docker/tasks/main.yml
@@ -46,6 +46,11 @@
     name: python-pip
     state: latest
 
+- name: Update pip to more recent version (but not py3 latest)
+  pip:
+    name: pip
+    version: 19.0
+
 - name: Install Docker SDK
   pip:
     name: docker


### PR DESCRIPTION
Without this update I was getting the error: 

```
Couldn't find index page for 'setuptools_scm' 
```

Updating to version 19.0 fixed this problem. Updating to the most recent version caused `pip` to fail because it used `python3` syntax, so 19.0 is a good solution.