### PR TITLE
Add HTTPS Redirects for HTTP connections in Ansible deployment

### DIFF
--- a/deploy/ansible/roles/proxy/tasks/main.yml
+++ b/deploy/ansible/roles/proxy/tasks/main.yml
@@ -64,8 +64,10 @@
     restart_policy: unless-stopped
     exposed_ports:
       - "8080"
+      - "8081"
     published_ports:
       - "{{ published_port }}:8080"
+      - "80:8081"
     networks:
       - name: esgf
     networks_cli_compatible: yes

--- a/deploy/ansible/roles/proxy/templates/ssl.proxy.conf.j2
+++ b/deploy/ansible/roles/proxy/templates/ssl.proxy.conf.j2
@@ -1,4 +1,11 @@
 # HTTP and HTTPS server blocks that proxy to the other containers running on this host
+server {
+  listen 8081 default_server;
+
+    server_name _;
+
+    return 301 https://$host$request_uri;
+}
 
 server {
     listen 8080 ssl http2 default_server;


### PR DESCRIPTION
The current SSL configuration for deploying ESGF docker via Ansible does not handle incoming HTTP requests via port 80. These requests will simply time out. Given existing data published with http will generate wget scripts using this address, these downloads fail unless the user manually adjusts the scripts.

A proposed solution is opening a new port on the proxy container for HTTP connections and redirecting the connection, in this case returning a 301 "Permanently Moved" message with the appropriate HTTPS address, so the wget request can establish the correct connection.

This solution only applies if all incoming traffic should be redirected to HTTPS. 