### PR TITLE
Fix for the logstash pipe bug in Ansible deployments

### DIFF
--- a/deploy/ansible/roles/data/tasks/fileserver_install.yml
+++ b/deploy/ansible/roles/data/tasks/fileserver_install.yml
@@ -32,6 +32,17 @@
         src: /dev/stderr
         force: yes
 
+    - name: Get stats of a file
+      stat:
+        path: /esg/logs/fileserver/access.log
+      register: log_file
+
+    - name: Delete log pipe from previous playbook versions
+      file:
+        path: /esg/logs/fileserver/access.log
+        state: absent
+      when: log_file.stat.isfifo
+
     - name: Ensure access log file exists
       file:
         path: /esg/logs/fileserver/access.log

--- a/deploy/ansible/roles/data/tasks/fileserver_install.yml
+++ b/deploy/ansible/roles/data/tasks/fileserver_install.yml
@@ -32,10 +32,10 @@
         src: /dev/stderr
         force: yes
 
-    - name: Make the access log pipe
-      command: mkfifo /esg/logs/fileserver/access.log
-      args:
-        creates: /esg/logs/fileserver/access.log
+    - name: Ensure access log file exists
+      file:
+        path: /esg/logs/fileserver/access.log
+        state: touch
 
     - name: Transfer ownership of logs to security context user
       file:

--- a/deploy/ansible/roles/data/tasks/logstash_install.yml
+++ b/deploy/ansible/roles/data/tasks/logstash_install.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: Ensure logrotate is installed
+  command: dnf install -y logrotate
+
+- name: Install the logrotate configuration file
+  template:
+    src: esg.logrotate.j2
+    dest: /etc/logrotate.d/esg
+
 - name: Create Docker network
   docker_network:
     name: esgf

--- a/deploy/ansible/roles/data/tasks/thredds_install.yml
+++ b/deploy/ansible/roles/data/tasks/thredds_install.yml
@@ -52,10 +52,21 @@
         - cache.log
         - localhost.log
 
-    - name: Make the access log pipe
-      command: mkfifo /esg/logs/thredds/localhost_access_log.txt
-      args:
-        creates: /esg/logs/thredds/localhost_access_log.txt
+    - name: Get stats of a file
+      stat:
+        path: /esg/logs/thredds/localhost_access_log.txt
+      register: log_file
+
+    - name: Delete log pipe from previous playbook versions
+      file:
+        path: /esg/logs/thredds/localhost_access_log.txt
+        state: absent
+      when: log_file.stat.isfifo
+
+    - name: Ensure access log file exists
+      file:
+        path: /esg/logs/thredds/localhost_access_log.txt
+        state: touch
 
     - name: Transfer ownership of logs to security context user
       file:

--- a/deploy/ansible/roles/data/templates/esg.logrotate.j2
+++ b/deploy/ansible/roles/data/templates/esg.logrotate.j2
@@ -1,0 +1,23 @@
+{% set containers = [] %}
+{% if 'data' in group_names and fileserver_enabled %}
+{{ containers.append(['fileserver', 'access.log']) }}
+{% endif %}
+{% if 'data' in group_names and thredds_enabled %}
+{{ containers.append(['thredds', 'localhost_access_log.txt']) }}
+{% endif %}
+{% for container in containers %}
+/esg/logs/{{ container.0 }}/{{ container.1 }} {
+    create 0640 root root
+    daily
+    rotate 10
+    missingok
+    notifempty
+    compress
+    delaycompress
+    sharedscripts
+    postrotate
+        /usr/bin/docker restart {{ container.0 }} > /dev/null 2>/dev/null || true
+    endscript
+}
+
+{% endfor %}


### PR DESCRIPTION
Swaps the log pipes for regular files in the THREDDS and fileserver containers. Logrotate should circumvent any disk space issues.