### PR TITLE
Add helm chart options to ease deployment to OpenShift

### DIFF
--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -117,6 +117,7 @@ The produced mounts will always be read-only.
 Generate TLS config for ingress.
 */}}
 {{- define "esgf.ingress.tls" }}
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
 tls:
   - hosts:
       - {{ .Values.hostname | quote }}
@@ -125,6 +126,7 @@ tls:
     {{- else }}
     secretName: {{ include "esgf.component.fullname" (list . "hostcert") }}
     {{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/deploy/kubernetes/chart/templates/fileServer/configmap.yaml
+++ b/deploy/kubernetes/chart/templates/fileServer/configmap.yaml
@@ -7,4 +7,7 @@ metadata:
   labels: {{ include "esgf.component.labels" (list . "fileServer" $fileServer.labels) | nindent 4 }}
 data:
   datasets.conf: {{ tpl (.Files.Get "files/fileServer/datasets.conf") . | quote }}
+{{ range $file, $content := $fileServer.extraNginxConf }}
+  {{ $file }}: {{ tpl $content . | quote }}
+{{- end }}
 {{- end -}}

--- a/deploy/kubernetes/chart/templates/fileServer/deployment.yaml
+++ b/deploy/kubernetes/chart/templates/fileServer/deployment.yaml
@@ -24,6 +24,9 @@ spec:
         checksum/logstash-pipelines: {{ include (print $.Template.BasePath "/logstash/pipelines.yaml") . | sha256sum }}
         checksum/logstash-certs: {{ include (print $.Template.BasePath "/logstash/certs.yaml") . | sha256sum }}
         {{- end }}
+        {{- with $fileServer.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with (default .Values.image.pullSecrets $fileServer.image.pullSecrets) }}
       imagePullSecrets: {{ toYaml . | nindent 8 }}

--- a/deploy/kubernetes/chart/templates/thredds/deployment.yaml
+++ b/deploy/kubernetes/chart/templates/thredds/deployment.yaml
@@ -28,6 +28,9 @@ spec:
         checksum/logstash-pipelines: {{ include (print $.Template.BasePath "/logstash/pipelines.yaml") . | sha256sum }}
         checksum/logstash-certs: {{ include (print $.Template.BasePath "/logstash/certs.yaml") . | sha256sum }}
         {{- end }}
+        {{- with $thredds.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with (default .Values.image.pullSecrets $thredds.image.pullSecrets) }}
       imagePullSecrets: {{ toYaml . | nindent 8 }}

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -356,6 +356,7 @@ data:
     # Image overrides for the file server image
     image:
       repository: nginx
+    extraNginxConf:
     # The number of replicas for the file server pod
     # If an hpa is configured, this is ignored - the hpa has full control over the number of replicas
     replicaCount: 1


### PR DESCRIPTION
OpenShift has some interesting requirements for deploying helm charts. These changes make it possible to fulfill those requirements with the ESGF helm chart. Specifically:

1. OpenShift uses `Route`s instead of `Ingress`es. They will automatically convert `Ingress` objects to multiple `Route` objects, but having the `tls:` section of the Ingress set causes the certificate provisioning for HTTPS to fail. I've [wrapped the section of the helper that generates the tls entry](deploy/kubernetes/chart/templates/_helpers.tpl) with a check for the OpenShift security API so that the section isn't generated when deploying to OpenShift
2. Some of the nginx extensions in the current nginx image (which are also currently unused) default to writing to temporary directories which (since they're unused) don't have `emptyDir`s mounted to them. Since OpenShift runs with an arbirary uid, this fails. Rather than mounting `emptyDir`s for each extension, I've added the possibility to define extra nginx configuration in the existing `configMap` which can be used to set those extensions to use other writable dirs such as `/tmp`
3. This is more of an OLCF requirement that strictly OpenShift, but is also a generally useful option. The OLCF requires annotations on the `Pod` objects in order to mount their storage systems. The current annotations: entries are applied to the controller object (`Deployment`, `StatefulSet`, etc) but not to the `Pod` objects themselves. This change adds the specified `Annotations` to the generated Pod objects in addition to their controller objects.

This changeset allows deploying to the OLCF OpenShift cluster with a values file like this:
```yaml
hostname: example.apps.onyx.ccs.ornl.gov

ingress:
  annotations:
    ccs.ornl.gov/requireAuth: "false"
    route.openshift.io/termination: edge
  labels:
    ccs.ornl.gov/externalRoute: "true"

data:
  podSecurityContext: null
  securityContext: null
  datasets:
  - name: CSS03
    path: css03_data
    location: /nl/themis/esgf/cli137/world-shared/globus/esg_dataroot/css03_data/

  fileServer:
    annotations:
      ccs.ornl.gov/fs: themis
    extraNginxConf:
      openshift.conf: |-
        scgi_temp_path /tmp/uwsgi;
        uwsgi_temp_path /tmp/uwsgi;
        proxy_temp_path /tmp/proxy_temp;
        fastcgi_temp_path /tmp/fastcgi_temp;
        client_body_temp_path /tmp/client_temp;
  thredds:
    annotations:
      ccs.ornl.gov/fs: themis
    extraVolumes:
    - name: thredds-templates
      emptyDir: {}
    - name: thredds-notebooks
      emptyDir: {}
    extraVolumeMounts:
    - name: thredds-templates
      mountPath: /opt/tomcat/content/thredds/templates
    - name: thredds-notebooks
      mountPath: /opt/tomcat/content/thredds/notebooks

index:
  solr:
    podSecurityContext: null
    securityContext: null
```