### PR TITLE
Allow helm chart threddsConfig override and runAs arbitrary uid

### DIFF
--- a/deploy/kubernetes/chart/files/thredds/threddsConfig.xml
+++ b/deploy/kubernetes/chart/files/thredds/threddsConfig.xml
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<threddsConfig>
+
+  <!-- all options are commented out in standard install - meaning use default values -->
+  <!-- see http://www.unidata.ucar.edu/projects/THREDDS/tech/reference/ThreddsConfigXMLFile.html -->
+  <serverInformation>
+    <name>ESGF THREDDS Data Server</name>
+    <logoUrl>/thredds/threddsIcon.png</logoUrl>
+    <logoAltText>ESGF THREDDS Data Server</logoAltText>
+
+    <abstract>Scientific Data</abstract>
+    <keywords>meteorology, atmosphere, climate, ocean, earth science</keywords>
+
+    <contact>
+      <name>Support</name>
+      <organization>ESGF</organization>
+      <email>esgf-user@lists.llnl.gov</email>
+      <!--phone></phone-->
+    </contact>
+    <hostInstitution>
+      <name>ESGF</name>
+      <webSite>https://esgf.llnl.gov/</webSite>
+      <logoUrl>https://esgf.llnl.gov/media/images/esgfSmall.png</logoUrl>
+      <logoAltText>ESGF</logoAltText>
+    </hostInstitution>
+  </serverInformation>
+
+  <ConfigCatalog>
+    <keepInMemory>100</keepInMemory>
+    <reread>check</reread>
+    <maxDatasets>1000000</maxDatasets>
+  </ConfigCatalog>
+
+  <!--@@esgf_las_entry@@-->
+
+  <!--
+  The <catalogRoot> element:
+  For catalogs you don't want visible from the /thredds/catalog.xml chain
+  of catalogs, you can use catalogRoot elements. Each catalog root config
+  catalog is crawled and used in configuring the TDS.
+
+  <catalogRoot>myExtraCatalog.xml</catalogRoot>
+  <catalogRoot>myOtherExtraCatalog.xml</catalogRoot>
+  -->
+
+  <!--
+   * Setup for generated HTML pages.
+   *
+   * NOTE: URLs may be absolute or relative, relative URLs must be relative
+   * to the webapp URL, i.e., http://server:port/thredds/.
+    -->
+  <htmlSetup>
+    <!--
+     * CSS documents used in generated HTML pages.
+     * The CSS document given in the "catalogCssUrl" element is used for all pages
+     * that are HTML catalog views. The CSS document given in the "standardCssUrl"
+     * element is used in all other generated HTML pages.
+     * -->
+    <standardCssUrl>tds.css</standardCssUrl>
+    <catalogCssUrl>tdsCat.css</catalogCssUrl>
+
+    <!--
+     * The URLs (relative to "/thredds/") and alternate text for both
+     * folder and dataset icons used in HTML catalog views.
+     * -->
+    <folderIconUrl>folder.gif</folderIconUrl>
+    <folderIconAlt>Folder</folderIconAlt>
+    <datasetIconUrl>dataset.gif</datasetIconUrl> <!-- Not currently used. -->
+    <datasetIconAlt>Dataset</datasetIconAlt>     <!-- Not currently used. -->
+
+  </htmlSetup>
+
+  <!--
+   The <CatalogServices> element:
+   - Services on local TDS served catalogs are always on.
+   - Services on remote catalogs are set with the allowRemote element
+   below. They are off by default (recommended).
+   -->
+  <!--@@esg_start_comment@@-->
+  <CatalogServices>
+    <allowRemote>false</allowRemote>
+  </CatalogServices>
+  <!--@@esg_end_comment@@-->
+
+  <!--
+  Configuring the CDM (netcdf-java library)
+  see http://www.unidata.ucar.edu/software/netcdf-java/reference/RuntimeLoading.html
+
+  <nj22Config
+    <ioServiceProvider class="edu.univ.ny.stuff.FooFiles"/>
+    <coordSysBuilder convention="foo" class="test.Foo"/>
+    <coordTransBuilder name="atmos_ln_sigma_coordinates" type="vertical" class="my.stuff.atmosSigmaLog"/>
+    <typedDatasetFactory datatype="Point" class="gov.noaa.obscure.file.Flabulate"/>
+    <table type="GRIB1" filename="/home/rkambic/grib/tables/userlookup.lst"/>
+    <table type="GRIB2" filename="/home/rkambic/grib/tables/grib2userparameters"/>
+  </nj22Config>
+  -->
+
+  <!--
+  CDM uses the DiskCache directory to store temporary files, like uncompressed files.
+  <DiskCache>
+    <alwaysUse>false</alwaysUse>
+    <dir>/data/tmp/thredds/cache/</dir>
+    <scour>1 hour</scour>
+    <maxSize>1 Gb</maxSize>
+  </DiskCache>
+  -->
+
+  <!--
+  Caching open NetcdfFile objects.
+  default is to allow 200 - 400 open files, cleanup every 10 minutes
+  <NetcdfFileCache>
+    <minFiles>200</minFiles>
+    <maxFiles>400</maxFiles>
+    <scour>10 min</scour>
+  </NetcdfFileCache>
+  -->
+
+  <!--
+  Caching open NetcdfDataset objects.
+   default allow 100 - 200 open datasets, cleanup every 10 minutes
+  <NetcdfDatasetCache>
+    <minFiles>100</minFiles>
+    <maxFiles>200</maxFiles>
+    <scour>10 min</scour>
+  </NetcdfDatasetCache>
+  -->
+
+  <!--
+  The <HTTPFileCache> element:
+  allow 20 - 40 open datasets, cleanup every 10 minutes
+  used by HTTP Range requests.
+  <HTTPFileCache>
+    <minFiles>20</minFiles>
+    <maxFiles>40</maxFiles>
+    <scour>10 min</scour>
+  </HTTPFileCache>
+  -->
+
+  <!--
+  Writing GRIB indexes.
+  <GribIndexing>
+    <setExtendIndex>false</setExtendIndex>
+    <alwaysUseCache>false</alwaysUseCache>
+  </GribIndexing>
+  -->
+
+  <!--
+  Persist joinNew aggregations to named directory. scour every 24 hours, delete stuff older than 30 days
+  <AggregationCache>
+    <dir>/data/tmp/thredds/aggcache/</dir>
+    <scour>24 hours</scour>
+    <maxAge>30 days</maxAge>
+  </AggregationCache>
+  -->
+
+  <!--
+  How to choose the template dataset for an aggregation. latest, random, or penultimate
+  <Aggregation>
+    <typicalDataset>random</typicalDataset>
+  </Aggregation>
+  -->
+
+  <NetcdfSubsetService>
+    <allow>true</allow>
+    <dir>/opt/tomcat/content/thredds/cache/ncSubsetCache/</dir>
+    <scour>10 min</scour>
+    <maxAge>-1 min</maxAge>
+  </NetcdfSubsetService>
+
+  <Opendap>
+    <ascLimit>50</ascLimit>
+    <binLimit>500</binLimit>
+    <serverVersion>opendap/3.7</serverVersion>
+  </Opendap>
+
+  <!--
+  The WCS Service is off by default.
+  Also, off by default (and encouraged) is operating on a remote dataset.
+  -->
+  <WCS>
+    <allow>true</allow>
+    <allowRemote>false</allowRemote>
+    <dir>/opt/tomcat/content/thredds/cache/wcsCache/</dir>
+    <scour>15 min</scour>
+    <maxAge>30 min</maxAge>
+  </WCS>
+
+  <WMS>
+    <allow>true</allow>
+    <allowRemote>false</allowRemote>
+    <maxImageWidth>2048</maxImageWidth>
+    <maxImageHeight>2048</maxImageHeight>
+  </WMS>
+
+  <NCISO>
+    <ncmlAllow>true</ncmlAllow>
+    <uddcAllow>true</uddcAllow>
+    <isoAllow>true</isoAllow>
+  </NCISO>
+
+  <!-- CatalogGen service is off by default.
+  <CatalogGen>
+    <allow>false</allow>
+  </CatalogGen>
+   -->
+
+  <!-- DLwriter service is off by default.
+       As is support for operating on remote catalogs.
+  <DLwriter>
+    <allow>false</allow>
+    <allowRemote>false</allowRemote>
+  </DLwriter>
+   -->
+
+  <!-- DqcService is off by default.
+  <DqcService>
+    <allow>false</allow>
+  </DqcService>
+   -->
+
+  <!--
+   Link to a Viewer application on the HTML page:
+   <Viewer>my.package.MyViewer</Viewer>
+   -->
+
+   <!--
+   Add a DataSource - essentially an IOSP with access to Servlet request parameters
+   <DatsetSource>my.package.DatsetSourceImpl</DatsetSource>
+   -->
+
+  <!--
+  Forecast Model Run Collection Inventory
+  <FmrcInventory>
+    <openType>XML_ONLY</openType>
+  </FmrcInventory>
+  -->
+
+  <!--
+  Modify Logging parameters. Normally use log4j.xml
+  <Logging>
+    <DatePattern></DatePattern>
+    <MaxFileSize></MaxFileSize>
+    <MaxFiles></MaxFiles>
+  </Logging>
+  -->
+
+</threddsConfig>

--- a/deploy/kubernetes/chart/templates/thredds/configmap-catalog.yaml
+++ b/deploy/kubernetes/chart/templates/thredds/configmap-catalog.yaml
@@ -1,0 +1,10 @@
+{{- $thredds := .Values.data.thredds -}}
+{{- if (and .Values.data.enabled $thredds.enabled (not $thredds.catalogVolume))  -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "esgf.component.fullname" (list . "thredds") }}-catalog
+  labels: {{ include "esgf.component.labels" (list . "thredds" $thredds.labels) | nindent 4 }}
+data:
+  catalog.xml: {{ tpl (default (.Files.Get "files/thredds/catalog.xml") (index $thredds.config "catalog.xml")) . | quote }}
+{{- end -}}

--- a/deploy/kubernetes/chart/templates/thredds/configmap-config.yaml
+++ b/deploy/kubernetes/chart/templates/thredds/configmap-config.yaml
@@ -3,8 +3,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "esgf.component.fullname" (list . "thredds") }}
+  name: {{ include "esgf.component.fullname" (list . "thredds") }}-config
   labels: {{ include "esgf.component.labels" (list . "thredds" $thredds.labels) | nindent 4 }}
 data:
-  catalog.xml: {{ tpl (.Files.Get "files/thredds/catalog.xml") . | quote }}
+  threddsConfig.xml: {{ tpl (default (.Files.Get "files/thredds/threddsConfig.xml") (index $thredds.config "threddsConfig.xml")) . | quote }}
 {{- end -}}

--- a/deploy/kubernetes/chart/templates/thredds/deployment.yaml
+++ b/deploy/kubernetes/chart/templates/thredds/deployment.yaml
@@ -21,13 +21,14 @@ spec:
         release/revision: {{ .Release.Revision | quote }}
         {{- else }}
         # If using templated catalogs, we only need to roll if the configmap changes
-        checksum/configmap: {{ include (print $.Template.BasePath "/thredds/configmap.yaml") . | sha256sum }}
+        checksum/catalog: {{ include (print $.Template.BasePath "/thredds/configmap-catalog.yaml") . | sha256sum }}
         {{- end }}
         {{- if $accessLogSidecar.enabled }}
         # When the access log sidecar is enabled, roll the deployment if the logstash pipelines or certificates change
         checksum/logstash-pipelines: {{ include (print $.Template.BasePath "/logstash/pipelines.yaml") . | sha256sum }}
         checksum/logstash-certs: {{ include (print $.Template.BasePath "/logstash/certs.yaml") . | sha256sum }}
         {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/thredds/configmap-config.yaml") . | sha256sum }}
         {{- with $thredds.annotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -137,15 +138,20 @@ spec:
           {{- end }}
           volumeMounts:
             - name: thredds-catalogs
-              mountPath: /opt/tomcat/content/thredds/esgcet
+              mountPath: /opt/tomcat/content/thredds/catalog.xml
+              subPath: catalog.xml
               readOnly: true
               {{- if (and $thredds.catalogVolume (not $thredds.localCache.enabled)) }}
               {{- with (omit (default dict $thredds.catalogVolume.mountOptions) "readOnly") }}
               {{ toYaml . | indent 14 | trim }}
               {{- end }}
               {{- end }}
-            - name: thredds-cache
-              mountPath: /opt/tomcat/content/thredds/cache
+            - name: thredds-config
+              mountPath: /opt/tomcat/content/thredds/threddsConfig.xml
+              subPath: threddsConfig.xml
+              readOnly: true
+            - name: thredds-work
+              mountPath: /opt/tomcat/content/thredds
             # The shared log volume is only required if the access log sidecar is enabled
             # It is also required for a readOnly root filesystem.
             - name: tomcat-logs
@@ -209,10 +215,13 @@ spec:
         {{- else }}
         - name: thredds-catalogs
           configMap:
-            name: {{ include "esgf.component.fullname" (list . "thredds") }}
+            name: {{ include "esgf.component.fullname" (list . "thredds") }}-catalog
         {{- end }}
-        # Each pod gets its own THREDDS cache directory on the local disk
-        - name: thredds-cache
+        - name: thredds-config
+          configMap:
+            name: {{ include "esgf.component.fullname" (list . "thredds") }}-config
+        # When ran with an arbitrary uid, give Thredds a writable space to copy its files into
+        - name: thredds-work
           emptyDir: {}
         # In order to use a read-only rootfs, we must put emptyDirs where we expect tomcat to write
         - name: tomcat-temp

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -349,6 +349,9 @@ data:
     # The tolerations for the THREDDS pod
     # See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
     tolerations:
+    config:
+      catalog.xml:
+      threddsConfig.xml:
 
   # Configuration for the file server pod
   fileServer:


### PR DESCRIPTION
Some kubernetes environments require running services as arbitrary UIDs. The Thredds image attempts to copy files to `/opt/tomcat/content/thredds` on startup which fails in these environments.

This PR mounts an `emptyDir` at `/opt/tomcat/content/thredds` to allow the startup procedure to write it's files. As a side effect, the `catalog.xml` and `threddsConfig.xml` baked into the image are overwritten with the empty directory. `catalog.xml` was already being mounted from a `configMap` so that hasn't changed, but now `threddsConfig.xml` is also mounted from a separate `configMap`.

Both `configMap`s default to the same existing documents, but can now be overridden at deploy time with something like `--set-file data.thredds.config."catalog\.xml"=/path/to/local/catalog.xml`