### PR TITLE
More flexible nginx configuration in helm chart

### DIFF
--- a/deploy/kubernetes/chart/files/fileServer/datasets.conf
+++ b/deploy/kubernetes/chart/files/fileServer/datasets.conf
@@ -14,6 +14,12 @@ server {
         return 404;
     }
 
+    # Basic metrics export, compatible with nginx exporter
+    # https://github.com/nginx/nginx-prometheus-exporter
+    location = /stub_status {
+        stub_status;
+    }
+
     # Create a location block for each dataset
     {{- range .Values.data.datasets }}
     location /thredds/fileServer/{{ .path }}/ {
@@ -22,6 +28,10 @@ server {
         proxy_pass https://{{ $s3.host }}:{{ $s3.port }}/{{ $s3.bucket }}/{{ trimAll "/" $s3.dataPath }}/;
         {{- else }}
         alias {{ trimSuffix "/" .location }}/;
+        autoindex on;
+        expires max;
+        sendfile on;
+        tcp_nopush on;
         try_files $uri =404;
         {{- end }}
     }

--- a/deploy/kubernetes/chart/templates/fileServer/configmap-nginx.yaml
+++ b/deploy/kubernetes/chart/templates/fileServer/configmap-nginx.yaml
@@ -1,0 +1,10 @@
+{{- $fileServer := .Values.data.fileServer -}}
+{{- if (and .Values.data.enabled $fileServer.enabled (index $fileServer "nginx.conf")) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "esgf.component.fullname" (list . "fileServer") }}-nginx-conf
+  labels: {{ include "esgf.component.labels" (list . "fileServer" $fileServer.labels) | nindent 4 }}
+data:
+  nginx.conf: {{ tpl (index $fileServer "nginx.conf") . | quote }}
+{{- end -}}

--- a/deploy/kubernetes/chart/templates/fileServer/configmap.yaml
+++ b/deploy/kubernetes/chart/templates/fileServer/configmap.yaml
@@ -8,6 +8,6 @@ metadata:
 data:
   datasets.conf: {{ tpl (.Files.Get "files/fileServer/datasets.conf") . | quote }}
 {{ range $file, $content := $fileServer.extraNginxConf }}
-  {{ $file }}: {{ tpl $content . | quote }}
+  {{ $file }}: {{ tpl $content $ | quote }}
 {{- end }}
 {{- end -}}

--- a/deploy/kubernetes/chart/templates/fileServer/deployment.yaml
+++ b/deploy/kubernetes/chart/templates/fileServer/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/fileServer/configmap.yaml") . | sha256sum }}
+        {{- if (index $fileServer "nginx.conf") }}
+        checksum/configmap-nginx: {{ include (print $.Template.BasePath "/fileServer/configmap-nginx.yaml") . | sha256sum }}
+        {{- end }}
         {{- if $accessLogSidecar.enabled }}
         # When the access log sidecar is enabled, roll the deployment if the logstash pipelines or certificates change
         checksum/logstash-pipelines: {{ include (print $.Template.BasePath "/logstash/pipelines.yaml") . | sha256sum }}
@@ -82,7 +85,7 @@ spec:
           securityContext: {{ toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: nginx-conf
+            - name: nginx-extra
               mountPath: /etc/nginx/conf.d
               readOnly: true
             # The shared log volume is only required if the access log sidecar is enabled
@@ -96,6 +99,11 @@ spec:
               mountPath: /var/lib/nginx/tmp
             - name: nginx-run
               mountPath: /run/nginx
+            {{- if (index $fileServer "nginx.conf") }}
+            - name: nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            {{- end }}
             {{- include "esgf.data.volumeMounts" . | nindent 12 }}
             {{- with $fileServer.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -135,7 +143,7 @@ spec:
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        - name: nginx-conf
+        - name: nginx-extra
           configMap:
             name: {{ include "esgf.component.fullname" (list . "fileServer") }}
         # In order to use a read-only root filesystem, we mount emptyDirs in places
@@ -144,6 +152,11 @@ spec:
           emptyDir: {}
         - name: nginx-run
           emptyDir: {}
+        {{- if (index $fileServer "nginx.conf") }}
+        - name: nginx-conf
+          configMap:
+            name: {{ include "esgf.component.fullname" (list . "fileServer") }}-nginx
+        {{- end }}
         # These volumes are only required if the access log sidecar is enabled
         {{- if $accessLogSidecar.enabled }}
         # Each pod gets a directory to hold the named pipes for the logs

--- a/deploy/kubernetes/chart/templates/fileServer/hpa.yaml
+++ b/deploy/kubernetes/chart/templates/fileServer/hpa.yaml
@@ -1,6 +1,6 @@
 {{- $fileServer := .Values.data.fileServer -}}
 {{- if (and .Values.data.enabled $fileServer.enabled $fileServer.hpa) -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "esgf.component.fullname" (list . "fileServer") }}

--- a/deploy/kubernetes/chart/templates/thredds/hpa.yaml
+++ b/deploy/kubernetes/chart/templates/thredds/hpa.yaml
@@ -1,6 +1,6 @@
 {{- $thredds := .Values.data.thredds -}}
 {{- if (and .Values.data.enabled $thredds.enabled $thredds.hpa) -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "esgf.component.fullname" (list . "thredds") }}

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -360,6 +360,18 @@ data:
     # Image overrides for the file server image
     image:
       repository: nginx
+    # Override the default /etc/nginx/nginx.conf
+    nginxConf:
+    # Expects a dict of file name -> content as strings
+    # The files with the specified content will be created in /etc/nginx/conf.d/
+    # Ex:
+    # extraNginxConf:
+    #   openshift.conf: |-
+    #     scgi_temp_path /tmp/uwsgi;
+    #     uwsgi_temp_path /tmp/uwsgi;
+    #     proxy_temp_path /tmp/proxy_temp;
+    #     fastcgi_temp_path /tmp/fastcgi_temp;
+    #     client_body_temp_path /tmp/client_temp;
     extraNginxConf:
     # The number of replicas for the file server pod
     # If an hpa is configured, this is ignored - the hpa has full control over the number of replicas


### PR DESCRIPTION
- Update HPA version from autoscaling/v2beta2 to autoscaling/v2
- Fix context not being passed to templated files passed in for /etc/nginx/conf.d/
- Add nginx `stub_status` location compatible with nginx prometheus exporter
- Explicitly set static file tuning parameters in datasets.conf
- New configmap to allow overriding of /etc/nginx/nginx.conf (useful for tuning `worker_connections` and other params that can't be set inside the `server {}` block where /etc/nginx/conf.d files are included)
- Add short comment to values.yaml to explain data.fileServer.nginxConf